### PR TITLE
Feature/rdss 1561 disabling content types

### DIFF
--- a/example.env
+++ b/example.env
@@ -19,9 +19,9 @@ WILLOW_EXPOSED_PORT=80
 # Serve Geoblacklight on port 81 (default is 3010)
 GEOBLACKLIGHT_EXPOSED_PORT=81
 
-# Enable speficic content types on a per institution basis
+# Enable specific content types on a per institution basis
 # uncomment to enable the relevant content type.
-# Content types that are not disabled can not be created and existing content will not appear on the site
+# Content types that are not disabled cannot be created and existing content will not appear on the site
 # By default RdssDataset content type is always enabled
 # WARNING: If there is existing content of a type that is not enabled this could lead to rails errors
 
@@ -31,7 +31,7 @@ GEOBLACKLIGHT_EXPOSED_PORT=81
 # ENABLE_ARTICLE_CONTENT_TYPE=true
 
 
-# Disable creation of new works for a speficic content type on a per institution basis
+# Disable creation of new works for a specific content type on a per institution basis
 # uncomment to disable new work for the relevant content type
 # The content type will not be available in the modal for creating a new work,
 # but existing content of this type will still display on the site

--- a/example.env
+++ b/example.env
@@ -18,3 +18,26 @@ WILLOW_EXPOSED_PORT=80
 
 # Serve Geoblacklight on port 81 (default is 3010)
 GEOBLACKLIGHT_EXPOSED_PORT=81
+
+# Enable speficic content types on a per institution basis
+# uncomment to enable the relevant content type.
+# Content types that are not disabled can not be created and existing content will not appear on the site
+# By default RdssDataset content type is always enabled
+# WARNING: If there is existing content of a type that is not enabled this could lead to rails errors
+
+# ENABLE_IMAGE_CONTENT_TYPE=true
+# ENABLE_BOOK_CONTENT_TYPE=true
+# ENABLE_DATASET_CONTENT_TYPE=true
+# ENABLE_ARTICLE_CONTENT_TYPE=true
+
+
+# Disable creation of new works for a speficic content type on a per institution basis
+# uncomment to disable new work for the relevant content type
+# The content type will not be available in the modal for creating a new work,
+# but existing content of this type will still display on the site
+
+# DISABLE_NEW_IMAGE_CONTENT=true
+# DISABLE_NEW_BOOK_CONTENT=true
+# DISABLE_NEW_DATASET_CONTENT=true
+# DISABLE_NEW_ARTICLE_CONTENT=true
+# DISABLE_NEW_RDSS_DATASET_CONTENT=true

--- a/willow/app/models/article.rb
+++ b/willow/app/models/article.rb
@@ -4,6 +4,10 @@ require "./lib/vocabularies/rioxxterms"
 class Article < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
 
+  # include methods to check for enabled and disabled content types
+  include EnableContentTypesBehaviour
+
+
   self.indexer = ArticleIndexer
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []

--- a/willow/app/models/book.rb
+++ b/willow/app/models/book.rb
@@ -3,6 +3,9 @@
 class Book < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
 
+  # include methods to check for enabled and disabled content types
+  include EnableContentTypesBehaviour
+
   self.indexer = BookIndexer
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []

--- a/willow/app/models/concerns/enable_content_types_behaviour.rb
+++ b/willow/app/models/concerns/enable_content_types_behaviour.rb
@@ -1,0 +1,29 @@
+# Shared functionality for Work models
+# adds methods to check if content type is enabled, or new content for this type is disabled
+module EnableContentTypesBehaviour
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    # Method to determine if content of this type is enabled by environment variables
+    # Checks if ENV[ENABLE_<type>_CONTENT_TYPE] == 'true'
+    # NB: RdssDataset is always enabled
+    def content_type_enabled?
+      # RdssDataset should always return true
+      return true if(self == RdssDataset)
+      # check environment variable
+      ENV["ENABLE_#{content_type_env_var_str}_CONTENT_TYPE"] == 'true'
+    end
+    
+    # Method to determine if creation of new content for this type is disabled by environment variables
+    # Checks if ENV[DISABLE_NEW_<type>_CONTENT] == 'true'
+    def new_content_of_type_disabled?
+      ENV["DISABLE_NEW_#{content_type_env_var_str}_CONTENT"] == 'true'
+    end
+
+    # content type name in the correct format for environment variables
+    # returns the uppercase and underscore version of the classname, E.G RDSS_DATASET
+    def content_type_env_var_str
+      self.name.underscore.upcase # E.G "RdssDataset" => "RDSS_DATASET"
+    end
+  end
+end

--- a/willow/app/models/dataset.rb
+++ b/willow/app/models/dataset.rb
@@ -3,6 +3,9 @@
 class Dataset < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
 
+  # include methods to check for enabled and disabled content types
+  include EnableContentTypesBehaviour  
+
   self.indexer = DatasetIndexer
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []

--- a/willow/app/models/image.rb
+++ b/willow/app/models/image.rb
@@ -3,6 +3,9 @@
 class Image < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
 
+  # include methods to check for enabled and disabled content types
+  include EnableContentTypesBehaviour
+
   self.indexer = ImageIndexer
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []

--- a/willow/app/models/rdss_dataset.rb
+++ b/willow/app/models/rdss_dataset.rb
@@ -3,6 +3,9 @@
 class RdssDataset < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
 
+  # include methods to check for enabled and disabled content types
+  include EnableContentTypesBehaviour  
+
   self.indexer = RdssDatasetIndexer
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []

--- a/willow/config/initializers/disable_new_content_of_type.rb
+++ b/willow/config/initializers/disable_new_content_of_type.rb
@@ -1,0 +1,21 @@
+# This initializer adds functionality to the hyrax gem class
+# Hyrax::SelectTypeListPresenter
+# This allows us to filter the modal for adding a new work and not include disabled content types
+Hyrax::SelectTypeListPresenter.class_eval do
+    
+    # redefine Hyrax::SelectTypeListPresenter#each
+    # so that it only yields a presenter for 
+    # content types that are not disabled
+    # original source is here
+    # https://github.com/CottageLabs/hyrax/blob/master/app/presenters/hyrax/select_type_list_presenter.rb#L33
+    def each
+      # authorized_models is an array of classes for the registered model types
+      # => [Article, Image, Book, Dataset, RdssDataset]
+      authorized_models.each do |model|
+        # only yield the presenter if new content of the content type is not disabled
+        unless model.new_content_of_type_disabled?
+          yield row_presenter.new(model)
+        end
+      end
+    end
+end

--- a/willow/config/initializers/hyrax.rb
+++ b/willow/config/initializers/hyrax.rb
@@ -1,14 +1,25 @@
 Hyrax.config do |config|
-  # Injected via `rails g hyrax:work Image`
-  config.register_curation_concern :image
-  # Injected via `rails g hyrax:work Book`
-  config.register_curation_concern :book
-  # Injected via `rails g hyrax:work Dataset`
-  config.register_curation_concern :dataset
-  # Injected via `rails g hyrax:work Article`
-  config.register_curation_concern :article
+  # Allow environment variables to enable registration of concern types
+  # NB: RdssDataset is always enabled
+  if ENV['ENABLE_IMAGE_CONTENT_TYPE'] == 'true'
+    # Injected via `rails g hyrax:work Image`
+    config.register_curation_concern :image
+  end
+  if ENV['ENABLE_BOOK_CONTENT_TYPE'] == 'true'
+    # Injected via `rails g hyrax:work Book`
+    config.register_curation_concern :book
+  end
+  if ENV['ENABLE_DATASET_CONTENT_TYPE'] == 'true'
+    # Injected via `rails g hyrax:work Dataset`
+    config.register_curation_concern :dataset
+  end
+  if ENV['ENABLE_ARTICLE_CONTENT_TYPE'] == 'true'
+    # Injected via `rails g hyrax:work Article`
+    config.register_curation_concern :article
+  end
   # Injected via `rails g hyrax:work RdssDataset`
   config.register_curation_concern :rdss_dataset
+  
   # Register roles that are expected by your implementation.
   # @see Hyrax::RoleRegistry for additional details.
   # @note there are magical roles as defined in Hyrax::RoleRegistry::MAGIC_ROLES

--- a/willow/config/routes.rb
+++ b/willow/config/routes.rb
@@ -31,6 +31,16 @@ Rails.application.routes.draw do
   end
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  # Add in routes for disabled content types to prevent rails errors in the featured content list
+  [Image, Article, Book, Dataset, RdssDataset].each do |content_type|
+    # If the content type is disabled, add in the url helper for hyrax_<type>_url
+    # This is to prevent rails errors in the featured content list if there is existing content
+    # The link to the content will render but lead to a 404 if followed
+    unless content_type.content_type_enabled?
+      get "disabled_content_type", to: redirect('404'), as: "hyrax_#{content_type.name.underscore}"
+    end
+  end
 end
 
 # Used to generate URLs in libraries that do not have access to the Rails request pipeline. The same settings

--- a/willow/spec/features/create_article_spec.rb
+++ b/willow/spec/features/create_article_spec.rb
@@ -12,29 +12,31 @@ RSpec.feature 'Create an Article', vcr: true do
     end
 
     scenario do
-      visit new_hyrax_article_path
+      if(Article.content_type_enabled?)
+        visit new_hyrax_article_path
 
-      fill_in 'Title', with: 'Test Article'
-      fill_in 'article_creator_nested_attributes_0_first_name', with: 'Alice'
-      fill_in 'article_creator_nested_attributes_0_last_name', with: 'Bob'
-      fill_in 'article_creator_nested_attributes_0_orcid', with: '0000-0000-0000-0000'
-      fill_in 'article_creator_nested_attributes_0_affiliation', with: 'University of Foo'
-      select('Author', from: 'article_creator_nested_attributes_0_role')
-      fill_in 'Publisher', with: 'Publisher of Foo'
-      fill_in 'article_date_attributes_0_date', with: '01/01/2001'
-      select('Journal Article/Review', from: 'article_resource_type')
-      select('Public Domain Mark 1.0', from: 'article_license_nested_attributes_0_webpage')
-      choose('open')
-      check('agreement')
-      click_on('Files')
-      attach_file('files[]', "#{fixture_path}/files/hello_world.pdf")
+        fill_in 'Title', with: 'Test Article'
+        fill_in 'article_creator_nested_attributes_0_first_name', with: 'Alice'
+        fill_in 'article_creator_nested_attributes_0_last_name', with: 'Bob'
+        fill_in 'article_creator_nested_attributes_0_orcid', with: '0000-0000-0000-0000'
+        fill_in 'article_creator_nested_attributes_0_affiliation', with: 'University of Foo'
+        select('Author', from: 'article_creator_nested_attributes_0_role')
+        fill_in 'Publisher', with: 'Publisher of Foo'
+        fill_in 'article_date_attributes_0_date', with: '01/01/2001'
+        select('Journal Article/Review', from: 'article_resource_type')
+        select('Public Domain Mark 1.0', from: 'article_license_nested_attributes_0_webpage')
+        choose('open')
+        check('agreement')
+        click_on('Files')
+        attach_file('files[]', "#{fixture_path}/files/hello_world.pdf")
 
 
-      # cannot save without invoking Fedora and thus a problem of unrepeatable tests results...
-      # click_on('Save')
-      # expect(page).to have_content 'Your files are being processed'
-      # expect(page).to have_content 'Test Article'
-      # expect(page).to have_content 'University of Foo'
+        # cannot save without invoking Fedora and thus a problem of unrepeatable tests results...
+        # click_on('Save')
+        # expect(page).to have_content 'Your files are being processed'
+        # expect(page).to have_content 'Test Article'
+        # expect(page).to have_content 'University of Foo'
+      end
     end
   end
 end

--- a/willow/spec/features/create_book_spec.rb
+++ b/willow/spec/features/create_book_spec.rb
@@ -12,19 +12,20 @@ RSpec.feature 'Create a Book', vcr: true do
     end
 
     scenario do
-      visit new_hyrax_book_path
+      if(Book.content_type_enabled?)
+        visit new_hyrax_book_path
 
-      fill_in 'Title', with: 'Test Book'
-      fill_in 'Creator', with: 'Alice Bob'
-      fill_in 'Keyword', with: 'Foo'
-      select('In Copyright', from: 'Rights statement')
-      choose('open')
-      check('agreement')
-      click_on('Files')
-      attach_file('files[]', "#{fixture_path}/files/hello_world.pdf")
+        fill_in 'Title', with: 'Test Book'
+        fill_in 'Creator', with: 'Alice Bob'
+        fill_in 'Keyword', with: 'Foo'
+        select('In Copyright', from: 'Rights statement')
+        choose('open')
+        check('agreement')
+        click_on('Files')
+        attach_file('files[]', "#{fixture_path}/files/hello_world.pdf")
 
-      # cannot save without invoking Fedora and thus a problem of unrepeatable tests results...
-
+        # cannot save without invoking Fedora and thus a problem of unrepeatable tests results...
+      end
     end
   end
 end

--- a/willow/spec/features/create_dataset_spec.rb
+++ b/willow/spec/features/create_dataset_spec.rb
@@ -12,24 +12,26 @@ RSpec.feature 'Create a Dataset', vcr: true do
     end
 
     scenario do
-      visit new_hyrax_dataset_path
+      if(Dataset.content_type_enabled?)
+        visit new_hyrax_dataset_path
 
-      fill_in 'Title', with: 'Test Dataset'
-      fill_in 'dataset_creator_nested_attributes_0_first_name', with: 'Alice'
-      fill_in 'dataset_creator_nested_attributes_0_last_name', with: 'Bob'
-      fill_in 'dataset_creator_nested_attributes_0_orcid', with: '0000-0000-0000-0000'
-      fill_in 'dataset_creator_nested_attributes_0_affiliation', with: 'University of Foo'
-      select('Data collector', from: 'dataset_creator_nested_attributes_0_role')
-      fill_in 'Publisher', with: 'Publisher of Foo'
-      fill_in 'dataset_date_attributes_0_date', with: '01/01/2001'
-      select('Dataset', from: 'Resource type')
-      select('Public Domain Mark 1.0', from: 'dataset_license_nested_attributes_0_webpage')
-      choose('open')
-      check('agreement')
-      click_on('Files')
-      attach_file('files[]', "#{fixture_path}/files/hello_world.pdf")
+        fill_in 'Title', with: 'Test Dataset'
+        fill_in 'dataset_creator_nested_attributes_0_first_name', with: 'Alice'
+        fill_in 'dataset_creator_nested_attributes_0_last_name', with: 'Bob'
+        fill_in 'dataset_creator_nested_attributes_0_orcid', with: '0000-0000-0000-0000'
+        fill_in 'dataset_creator_nested_attributes_0_affiliation', with: 'University of Foo'
+        select('Data collector', from: 'dataset_creator_nested_attributes_0_role')
+        fill_in 'Publisher', with: 'Publisher of Foo'
+        fill_in 'dataset_date_attributes_0_date', with: '01/01/2001'
+        select('Dataset', from: 'Resource type')
+        select('Public Domain Mark 1.0', from: 'dataset_license_nested_attributes_0_webpage')
+        choose('open')
+        check('agreement')
+        click_on('Files')
+        attach_file('files[]', "#{fixture_path}/files/hello_world.pdf")
 
-      # cannot save without invoking Fedora and thus a problem of unrepeatable tests results...
+        # cannot save without invoking Fedora and thus a problem of unrepeatable tests results...
+      end
     end
   end
 end

--- a/willow/spec/features/create_image_spec.rb
+++ b/willow/spec/features/create_image_spec.rb
@@ -12,18 +12,20 @@ RSpec.feature 'Create a Image', vcr: true do
     end
 
     scenario do
-      visit new_hyrax_image_path
+      if(Image.content_type_enabled?)
+        visit new_hyrax_image_path
 
-      fill_in 'Title', with: 'Test Image'
-      fill_in 'Creator', with: 'Alice Bob'
-      fill_in 'Keyword', with: 'Foo'
-      select('In Copyright', from: 'Rights statement')
-      choose('open')
-      check('agreement')
-      click_on('Files')
-      attach_file('files[]', "#{fixture_path}/files/hello_world.pdf")
+        fill_in 'Title', with: 'Test Image'
+        fill_in 'Creator', with: 'Alice Bob'
+        fill_in 'Keyword', with: 'Foo'
+        select('In Copyright', from: 'Rights statement')
+        choose('open')
+        check('agreement')
+        click_on('Files')
+        attach_file('files[]', "#{fixture_path}/files/hello_world.pdf")
 
-      # cannot save without invoking Fedora and thus a problem of unrepeatable tests results...
+        # cannot save without invoking Fedora and thus a problem of unrepeatable tests results...
+      end
     end
   end
 end

--- a/willow/spec/fixtures/vcr/Create_a_Book/a_logged_in_user/1_1_1.yml
+++ b/willow/spec/fixtures/vcr/Create_a_Book/a_logged_in_user/1_1_1.yml
@@ -19,23 +19,23 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:28 GMT
+      - Wed, 04 Oct 2017 17:18:10 GMT
       Etag:
-      - '"MzkwMDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"MTkwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
       - '1976'
     body:
       encoding: UTF-8
-      string: '{"responseHeader":{"status":0,"QTime":5,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["{!terms
+      string: '{"responseHeader":{"status":0,"QTime":2,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["{!terms
         f=id}","{!terms f=has_model_ssim}AdminSet"],"f.rating_sim.facet.limit":"6","f.creator_sim.facet.limit":"6","f.member_of_collections_ssim.facet.limit":"6","f.contributor_sim.facet.limit":"6","f.subject_nested_sim.facet.limit":"6","f.organisation_nested_sim.facet.limit":"6","qf":"title_tesim
         description_tesim creator_tesim keyword_tesim","f.based_near_label_sim.facet.limit":"6","f.category_sim.facet.limit":"6","wt":"json","f.keyword_sim.facet.limit":"6","facet.field":["human_readable_type_sim","resource_type_sim","creator_sim","creator_nested_sim","contributor_sim","keyword_sim","subject_sim","subject_nested_sim","language_sim","based_near_label_sim","publisher_sim","funder_sim","tagged_version_sim","file_format_sim","member_of_collections_ssim","rating_sim","category_sim","rights_holder_sim","organisation_nested_sim","generic_type_sim"],"qt":"search","f.tagged_version_sim.facet.limit":"6","f.publisher_sim.facet.limit":"6","sort":"score
         desc, system_create_dtsi desc","rows":"100","f.human_readable_type_sim.facet.limit":"6","f.creator_nested_sim.facet.limit":"6","f.funder_sim.facet.limit":"6","facet":"true","f.subject_sim.facet.limit":"6"}},"response":{"numFound":0,"start":0,"maxScore":0.0,"docs":[]},"facet_counts":{"facet_queries":{},"facet_fields":{"human_readable_type_sim":[],"resource_type_sim":[],"creator_sim":[],"creator_nested_sim":[],"contributor_sim":[],"keyword_sim":[],"subject_sim":[],"subject_nested_sim":[],"language_sim":[],"based_near_label_sim":[],"publisher_sim":[],"funder_sim":[],"tagged_version_sim":[],"file_format_sim":[],"member_of_collections_ssim":[],"rating_sim":[],"category_sim":[],"rights_holder_sim":[],"organisation_nested_sim":[],"generic_type_sim":[]},"facet_ranges":{},"facet_intervals":{},"facet_heatmaps":{}}}
 
 '
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:36 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:25 GMT
 - request:
     method: get
     uri: http://solr:8983/solr/willow_test/select?f.based_near_label_sim.facet.limit=6&f.category_sim.facet.limit=6&f.contributor_sim.facet.limit=6&f.creator_nested_sim.facet.limit=6&f.creator_sim.facet.limit=6&f.file_format_sim.facet.limit=6&f.funder_sim.facet.limit=6&f.human_readable_type_sim.facet.limit=6&f.keyword_sim.facet.limit=6&f.language_sim.facet.limit=6&f.member_of_collections_ssim.facet.limit=6&f.organisation_nested_sim.facet.limit=6&f.publisher_sim.facet.limit=6&f.rating_sim.facet.limit=6&f.resource_type_sim.facet.limit=6&f.rights_holder_sim.facet.limit=6&f.subject_nested_sim.facet.limit=6&f.subject_sim.facet.limit=6&f.tagged_version_sim.facet.limit=6&facet=true&facet.field=generic_type_sim&fq=%7B!terms%20f=has_model_ssim%7DAdminSet&qf=title_tesim%20description_tesim%20creator_tesim%20keyword_tesim&qt=search&rows=100&sort=score%20desc,%20system_create_dtsi%20desc&wt=json
@@ -55,23 +55,23 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:28 GMT
+      - Wed, 04 Oct 2017 17:18:10 GMT
       Etag:
-      - '"MzkwMDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"MTkwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
       - '1976'
     body:
       encoding: UTF-8
-      string: '{"responseHeader":{"status":0,"QTime":2,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["{!terms
+      string: '{"responseHeader":{"status":0,"QTime":3,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["{!terms
         f=id}","{!terms f=has_model_ssim}AdminSet"],"f.rating_sim.facet.limit":"6","f.creator_sim.facet.limit":"6","f.member_of_collections_ssim.facet.limit":"6","f.contributor_sim.facet.limit":"6","f.subject_nested_sim.facet.limit":"6","f.organisation_nested_sim.facet.limit":"6","qf":"title_tesim
         description_tesim creator_tesim keyword_tesim","f.based_near_label_sim.facet.limit":"6","f.category_sim.facet.limit":"6","wt":"json","f.keyword_sim.facet.limit":"6","facet.field":["human_readable_type_sim","resource_type_sim","creator_sim","creator_nested_sim","contributor_sim","keyword_sim","subject_sim","subject_nested_sim","language_sim","based_near_label_sim","publisher_sim","funder_sim","tagged_version_sim","file_format_sim","member_of_collections_ssim","rating_sim","category_sim","rights_holder_sim","organisation_nested_sim","generic_type_sim"],"qt":"search","f.tagged_version_sim.facet.limit":"6","f.publisher_sim.facet.limit":"6","sort":"score
         desc, system_create_dtsi desc","rows":"100","f.human_readable_type_sim.facet.limit":"6","f.creator_nested_sim.facet.limit":"6","f.funder_sim.facet.limit":"6","facet":"true","f.subject_sim.facet.limit":"6"}},"response":{"numFound":0,"start":0,"maxScore":0.0,"docs":[]},"facet_counts":{"facet_queries":{},"facet_fields":{"human_readable_type_sim":[],"resource_type_sim":[],"creator_sim":[],"creator_nested_sim":[],"contributor_sim":[],"keyword_sim":[],"subject_sim":[],"subject_nested_sim":[],"language_sim":[],"based_near_label_sim":[],"publisher_sim":[],"funder_sim":[],"tagged_version_sim":[],"file_format_sim":[],"member_of_collections_ssim":[],"rating_sim":[],"category_sim":[],"rights_holder_sim":[],"organisation_nested_sim":[],"generic_type_sim":[]},"facet_ranges":{},"facet_intervals":{},"facet_heatmaps":{}}}
 
 '
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:37 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:27 GMT
 - request:
     method: get
     uri: http://solr:8983/solr/willow_test/select?f.based_near_label_sim.facet.limit=6&f.category_sim.facet.limit=6&f.contributor_sim.facet.limit=6&f.creator_nested_sim.facet.limit=6&f.creator_sim.facet.limit=6&f.file_format_sim.facet.limit=6&f.funder_sim.facet.limit=6&f.human_readable_type_sim.facet.limit=6&f.keyword_sim.facet.limit=6&f.language_sim.facet.limit=6&f.member_of_collections_ssim.facet.limit=6&f.organisation_nested_sim.facet.limit=6&f.publisher_sim.facet.limit=6&f.rating_sim.facet.limit=6&f.resource_type_sim.facet.limit=6&f.rights_holder_sim.facet.limit=6&f.subject_nested_sim.facet.limit=6&f.subject_sim.facet.limit=6&f.tagged_version_sim.facet.limit=6&facet=true&facet.field=generic_type_sim&fq=-suppressed_bsi:true&qf=title_tesim%20description_tesim%20creator_tesim%20keyword_tesim&qt=search&rows=100&sort=title_si%20asc&wt=json
@@ -91,24 +91,67 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:28 GMT
+      - Wed, 04 Oct 2017 17:18:10 GMT
       Etag:
-      - '"MzkwMDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"MTkwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
       - '2101'
     body:
       encoding: UTF-8
-      string: '{"responseHeader":{"status":0,"QTime":3,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["({!terms
-        f=edit_access_group_ssim}public,registered) OR edit_access_person_ssim:email\\-256685640839324916198076764145679930348@test.com","{!terms
+      string: '{"responseHeader":{"status":0,"QTime":4,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["({!terms
+        f=edit_access_group_ssim}public,registered) OR edit_access_person_ssim:email\\-114319035827911355670370217882408880284@test.com","{!terms
         f=has_model_ssim}Collection","-suppressed_bsi:true"],"f.rating_sim.facet.limit":"6","f.creator_sim.facet.limit":"6","f.member_of_collections_ssim.facet.limit":"6","f.contributor_sim.facet.limit":"6","f.subject_nested_sim.facet.limit":"6","f.organisation_nested_sim.facet.limit":"6","qf":"title_tesim
         description_tesim creator_tesim keyword_tesim","f.based_near_label_sim.facet.limit":"6","f.category_sim.facet.limit":"6","wt":"json","f.keyword_sim.facet.limit":"6","facet.field":["human_readable_type_sim","resource_type_sim","creator_sim","creator_nested_sim","contributor_sim","keyword_sim","subject_sim","subject_nested_sim","language_sim","based_near_label_sim","publisher_sim","funder_sim","tagged_version_sim","file_format_sim","member_of_collections_ssim","rating_sim","category_sim","rights_holder_sim","organisation_nested_sim","generic_type_sim"],"qt":"search","f.tagged_version_sim.facet.limit":"6","f.publisher_sim.facet.limit":"6","sort":"title_si
         asc","rows":"100","f.human_readable_type_sim.facet.limit":"6","f.creator_nested_sim.facet.limit":"6","f.funder_sim.facet.limit":"6","facet":"true","f.subject_sim.facet.limit":"6"}},"response":{"numFound":0,"start":0,"maxScore":0.0,"docs":[]},"facet_counts":{"facet_queries":{},"facet_fields":{"human_readable_type_sim":[],"resource_type_sim":[],"creator_sim":[],"creator_nested_sim":[],"contributor_sim":[],"keyword_sim":[],"subject_sim":[],"subject_nested_sim":[],"language_sim":[],"based_near_label_sim":[],"publisher_sim":[],"funder_sim":[],"tagged_version_sim":[],"file_format_sim":[],"member_of_collections_ssim":[],"rating_sim":[],"category_sim":[],"rights_holder_sim":[],"organisation_nested_sim":[],"generic_type_sim":[]},"facet_ranges":{},"facet_intervals":{},"facet_heatmaps":{}}}
 
 '
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:37 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:27 GMT
+- request:
+    method: head
+    uri: http://fedora:8080/rest/willow_test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Etag:
+      - W/"f35e0ddcf5120829eeccebcd791907adcf2ef49b"
+      Last-Modified:
+      - Wed, 04 Oct 2017 17:18:09 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Content-Type:
+      - application/x-turtle
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 04 Oct 2017 17:22:27 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 04 Oct 2017 17:22:27 GMT
 - request:
     method: post
     uri: http://fedora:8080/rest/willow_test
@@ -134,25 +177,25 @@ http_interactions:
       message: ''
     headers:
       Etag:
-      - W/"878ef7dec175e477def2d3f2c43fa725ec9c5eb5"
+      - W/"2238c93ae4bbd1637a048da56280c1e2ebf55cd3"
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:37 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
       Location:
-      - http://fedora:8080/rest/willow_test/52/db/3e/7c/52db3e7c-3fe7-4c82-b23d-bee716aff5b8
+      - http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a
       Content-Type:
       - text/plain
       Content-Length:
       - '84'
       Date:
-      - Wed, 04 Oct 2017 17:22:37 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
     body:
       encoding: UTF-8
-      string: http://fedora:8080/rest/willow_test/52/db/3e/7c/52db3e7c-3fe7-4c82-b23d-bee716aff5b8
+      string: http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:37 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:28 GMT
 - request:
     method: get
-    uri: http://fedora:8080/rest/willow_test/52/db/3e/7c/52db3e7c-3fe7-4c82-b23d-bee716aff5b8
+    uri: http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a
     body:
       encoding: US-ASCII
       string: ''
@@ -173,9 +216,9 @@ http_interactions:
       message: ''
     headers:
       Etag:
-      - W/"878ef7dec175e477def2d3f2c43fa725ec9c5eb5"
+      - W/"2238c93ae4bbd1637a048da56280c1e2ebf55cd3"
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:37 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -196,7 +239,7 @@ http_interactions:
       Content-Length:
       - '3285'
       Date:
-      - Wed, 04 Oct 2017 17:22:37 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
     body:
       encoding: UTF-8
       string: |
@@ -244,26 +287,26 @@ http_interactions:
         @prefix config:  <info:fedoraconfig/> .
         @prefix dc:  <http://purl.org/dc/elements/1.1/> .
 
-        <http://fedora:8080/rest/willow_test/52/db/3e/7c/52db3e7c-3fe7-4c82-b23d-bee716aff5b8>
+        <http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a>
                 rdf:type               fedora:Container ;
                 rdf:type               fedora:Resource ;
                 fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
                 fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
-                fedora:created         "2017-10-04T17:22:37.485Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-                fedora:lastModified    "2017-10-04T17:22:37.485Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:created         "2017-10-04T17:22:28.021Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:lastModified    "2017-10-04T17:22:28.021Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
                 ns001:hasModel         "Hydra::AccessControl"^^<http://www.w3.org/2001/XMLSchema#string> ;
                 rdf:type               ldp:RDFSource ;
                 rdf:type               ldp:Container ;
                 fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
                 fedora:hasParent       <http://fedora:8080/rest/willow_test> .
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:37 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:28 GMT
 - request:
     method: post
     uri: http://solr:8983/solr/willow_test/update?softCommit=true&wt=json
     body:
       encoding: UTF-8
-      string: '[{"system_create_dtsi":"2017-10-04T17:22:37Z","system_modified_dtsi":"2017-10-04T17:22:37Z","has_model_ssim":"Hydra::AccessControl","id":"52db3e7c-3fe7-4c82-b23d-bee716aff5b8"}]'
+      string: '[{"system_create_dtsi":"2017-10-04T17:22:28Z","system_modified_dtsi":"2017-10-04T17:22:28Z","has_model_ssim":"Hydra::AccessControl","id":"1e7f8fb3-17dd-42fd-a500-e57203cf7d8a"}]'
     headers:
       User-Agent:
       - Faraday v0.12.2
@@ -284,14 +327,14 @@ http_interactions:
       - '43'
     body:
       encoding: UTF-8
-      string: '{"responseHeader":{"status":0,"QTime":22}}
+      string: '{"responseHeader":{"status":0,"QTime":18}}
 
 '
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:37 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:28 GMT
 - request:
     method: get
-    uri: http://fedora:8080/rest/willow_test/52/db/3e/7c/52db3e7c-3fe7-4c82-b23d-bee716aff5b8
+    uri: http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a
     body:
       encoding: US-ASCII
       string: ''
@@ -312,9 +355,9 @@ http_interactions:
       message: ''
     headers:
       Etag:
-      - W/"878ef7dec175e477def2d3f2c43fa725ec9c5eb5"
+      - W/"2238c93ae4bbd1637a048da56280c1e2ebf55cd3"
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:37 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -335,7 +378,7 @@ http_interactions:
       Content-Length:
       - '3285'
       Date:
-      - Wed, 04 Oct 2017 17:22:37 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
     body:
       encoding: UTF-8
       string: |
@@ -383,18 +426,18 @@ http_interactions:
         @prefix config:  <info:fedoraconfig/> .
         @prefix dc:  <http://purl.org/dc/elements/1.1/> .
 
-        <http://fedora:8080/rest/willow_test/52/db/3e/7c/52db3e7c-3fe7-4c82-b23d-bee716aff5b8>
+        <http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a>
                 rdf:type               fedora:Container ;
                 rdf:type               fedora:Resource ;
                 fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
                 fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
-                fedora:created         "2017-10-04T17:22:37.485Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-                fedora:lastModified    "2017-10-04T17:22:37.485Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:created         "2017-10-04T17:22:28.021Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:lastModified    "2017-10-04T17:22:28.021Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
                 ns001:hasModel         "Hydra::AccessControl"^^<http://www.w3.org/2001/XMLSchema#string> ;
                 rdf:type               ldp:RDFSource ;
                 rdf:type               ldp:Container ;
                 fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
                 fedora:hasParent       <http://fedora:8080/rest/willow_test> .
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:37 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:28 GMT
 recorded_with: VCR 3.0.3

--- a/willow/spec/fixtures/vcr/Create_a_Dataset/a_logged_in_user/1_1_1.yml
+++ b/willow/spec/fixtures/vcr/Create_a_Dataset/a_logged_in_user/1_1_1.yml
@@ -19,9 +19,9 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:37 GMT
+      - Wed, 04 Oct 2017 17:18:10 GMT
       Etag:
-      - '"NTAwMDAwMDAwMDAwMDAwU29scg=="'
+      - '"MTkwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
@@ -35,7 +35,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:38 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:25 GMT
 - request:
     method: get
     uri: http://solr:8983/solr/willow_test/select?f.based_near_label_sim.facet.limit=6&f.category_sim.facet.limit=6&f.contributor_sim.facet.limit=6&f.creator_nested_sim.facet.limit=6&f.creator_sim.facet.limit=6&f.file_format_sim.facet.limit=6&f.funder_sim.facet.limit=6&f.human_readable_type_sim.facet.limit=6&f.keyword_sim.facet.limit=6&f.language_sim.facet.limit=6&f.member_of_collections_ssim.facet.limit=6&f.organisation_nested_sim.facet.limit=6&f.publisher_sim.facet.limit=6&f.rating_sim.facet.limit=6&f.resource_type_sim.facet.limit=6&f.rights_holder_sim.facet.limit=6&f.subject_nested_sim.facet.limit=6&f.subject_sim.facet.limit=6&f.tagged_version_sim.facet.limit=6&facet=true&facet.field=generic_type_sim&fq=%7B!terms%20f=has_model_ssim%7DAdminSet&qf=title_tesim%20description_tesim%20creator_tesim%20keyword_tesim&qt=search&rows=100&sort=score%20desc,%20system_create_dtsi%20desc&wt=json
@@ -55,23 +55,23 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:37 GMT
+      - Wed, 04 Oct 2017 17:18:10 GMT
       Etag:
-      - '"NTAwMDAwMDAwMDAwMDAwU29scg=="'
+      - '"MTkwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
       - '1976'
     body:
       encoding: UTF-8
-      string: '{"responseHeader":{"status":0,"QTime":2,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["{!terms
+      string: '{"responseHeader":{"status":0,"QTime":3,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["{!terms
         f=id}","{!terms f=has_model_ssim}AdminSet"],"f.rating_sim.facet.limit":"6","f.creator_sim.facet.limit":"6","f.member_of_collections_ssim.facet.limit":"6","f.contributor_sim.facet.limit":"6","f.subject_nested_sim.facet.limit":"6","f.organisation_nested_sim.facet.limit":"6","qf":"title_tesim
         description_tesim creator_tesim keyword_tesim","f.based_near_label_sim.facet.limit":"6","f.category_sim.facet.limit":"6","wt":"json","f.keyword_sim.facet.limit":"6","facet.field":["human_readable_type_sim","resource_type_sim","creator_sim","creator_nested_sim","contributor_sim","keyword_sim","subject_sim","subject_nested_sim","language_sim","based_near_label_sim","publisher_sim","funder_sim","tagged_version_sim","file_format_sim","member_of_collections_ssim","rating_sim","category_sim","rights_holder_sim","organisation_nested_sim","generic_type_sim"],"qt":"search","f.tagged_version_sim.facet.limit":"6","f.publisher_sim.facet.limit":"6","sort":"score
         desc, system_create_dtsi desc","rows":"100","f.human_readable_type_sim.facet.limit":"6","f.creator_nested_sim.facet.limit":"6","f.funder_sim.facet.limit":"6","facet":"true","f.subject_sim.facet.limit":"6"}},"response":{"numFound":0,"start":0,"maxScore":0.0,"docs":[]},"facet_counts":{"facet_queries":{},"facet_fields":{"human_readable_type_sim":[],"resource_type_sim":[],"creator_sim":[],"creator_nested_sim":[],"contributor_sim":[],"keyword_sim":[],"subject_sim":[],"subject_nested_sim":[],"language_sim":[],"based_near_label_sim":[],"publisher_sim":[],"funder_sim":[],"tagged_version_sim":[],"file_format_sim":[],"member_of_collections_ssim":[],"rating_sim":[],"category_sim":[],"rights_holder_sim":[],"organisation_nested_sim":[],"generic_type_sim":[]},"facet_ranges":{},"facet_intervals":{},"facet_heatmaps":{}}}
 
 '
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:38 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:27 GMT
 - request:
     method: get
     uri: http://solr:8983/solr/willow_test/select?f.based_near_label_sim.facet.limit=6&f.category_sim.facet.limit=6&f.contributor_sim.facet.limit=6&f.creator_nested_sim.facet.limit=6&f.creator_sim.facet.limit=6&f.file_format_sim.facet.limit=6&f.funder_sim.facet.limit=6&f.human_readable_type_sim.facet.limit=6&f.keyword_sim.facet.limit=6&f.language_sim.facet.limit=6&f.member_of_collections_ssim.facet.limit=6&f.organisation_nested_sim.facet.limit=6&f.publisher_sim.facet.limit=6&f.rating_sim.facet.limit=6&f.resource_type_sim.facet.limit=6&f.rights_holder_sim.facet.limit=6&f.subject_nested_sim.facet.limit=6&f.subject_sim.facet.limit=6&f.tagged_version_sim.facet.limit=6&facet=true&facet.field=generic_type_sim&fq=-suppressed_bsi:true&qf=title_tesim%20description_tesim%20creator_tesim%20keyword_tesim&qt=search&rows=100&sort=title_si%20asc&wt=json
@@ -91,24 +91,67 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:37 GMT
+      - Wed, 04 Oct 2017 17:18:10 GMT
       Etag:
-      - '"NTAwMDAwMDAwMDAwMDAwU29scg=="'
+      - '"MTkwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
       - '2101'
     body:
       encoding: UTF-8
-      string: '{"responseHeader":{"status":0,"QTime":2,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["({!terms
-        f=edit_access_group_ssim}public,registered) OR edit_access_person_ssim:email\\-127359354552898370717911216491251740992@test.com","{!terms
+      string: '{"responseHeader":{"status":0,"QTime":4,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["({!terms
+        f=edit_access_group_ssim}public,registered) OR edit_access_person_ssim:email\\-114319035827911355670370217882408880284@test.com","{!terms
         f=has_model_ssim}Collection","-suppressed_bsi:true"],"f.rating_sim.facet.limit":"6","f.creator_sim.facet.limit":"6","f.member_of_collections_ssim.facet.limit":"6","f.contributor_sim.facet.limit":"6","f.subject_nested_sim.facet.limit":"6","f.organisation_nested_sim.facet.limit":"6","qf":"title_tesim
         description_tesim creator_tesim keyword_tesim","f.based_near_label_sim.facet.limit":"6","f.category_sim.facet.limit":"6","wt":"json","f.keyword_sim.facet.limit":"6","facet.field":["human_readable_type_sim","resource_type_sim","creator_sim","creator_nested_sim","contributor_sim","keyword_sim","subject_sim","subject_nested_sim","language_sim","based_near_label_sim","publisher_sim","funder_sim","tagged_version_sim","file_format_sim","member_of_collections_ssim","rating_sim","category_sim","rights_holder_sim","organisation_nested_sim","generic_type_sim"],"qt":"search","f.tagged_version_sim.facet.limit":"6","f.publisher_sim.facet.limit":"6","sort":"title_si
         asc","rows":"100","f.human_readable_type_sim.facet.limit":"6","f.creator_nested_sim.facet.limit":"6","f.funder_sim.facet.limit":"6","facet":"true","f.subject_sim.facet.limit":"6"}},"response":{"numFound":0,"start":0,"maxScore":0.0,"docs":[]},"facet_counts":{"facet_queries":{},"facet_fields":{"human_readable_type_sim":[],"resource_type_sim":[],"creator_sim":[],"creator_nested_sim":[],"contributor_sim":[],"keyword_sim":[],"subject_sim":[],"subject_nested_sim":[],"language_sim":[],"based_near_label_sim":[],"publisher_sim":[],"funder_sim":[],"tagged_version_sim":[],"file_format_sim":[],"member_of_collections_ssim":[],"rating_sim":[],"category_sim":[],"rights_holder_sim":[],"organisation_nested_sim":[],"generic_type_sim":[]},"facet_ranges":{},"facet_intervals":{},"facet_heatmaps":{}}}
 
 '
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:38 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:27 GMT
+- request:
+    method: head
+    uri: http://fedora:8080/rest/willow_test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Etag:
+      - W/"f35e0ddcf5120829eeccebcd791907adcf2ef49b"
+      Last-Modified:
+      - Wed, 04 Oct 2017 17:18:09 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Content-Type:
+      - application/x-turtle
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 04 Oct 2017 17:22:27 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 04 Oct 2017 17:22:27 GMT
 - request:
     method: post
     uri: http://fedora:8080/rest/willow_test
@@ -134,25 +177,25 @@ http_interactions:
       message: ''
     headers:
       Etag:
-      - W/"3984243991d6aaf23b13a924f94e6c10a88386fa"
+      - W/"2238c93ae4bbd1637a048da56280c1e2ebf55cd3"
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:38 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
       Location:
-      - http://fedora:8080/rest/willow_test/15/77/51/7d/1577517d-f8ba-4ceb-a066-7ec0210dd458
+      - http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a
       Content-Type:
       - text/plain
       Content-Length:
       - '84'
       Date:
-      - Wed, 04 Oct 2017 17:22:38 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
     body:
       encoding: UTF-8
-      string: http://fedora:8080/rest/willow_test/15/77/51/7d/1577517d-f8ba-4ceb-a066-7ec0210dd458
+      string: http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:38 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:28 GMT
 - request:
     method: get
-    uri: http://fedora:8080/rest/willow_test/15/77/51/7d/1577517d-f8ba-4ceb-a066-7ec0210dd458
+    uri: http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a
     body:
       encoding: US-ASCII
       string: ''
@@ -173,9 +216,9 @@ http_interactions:
       message: ''
     headers:
       Etag:
-      - W/"3984243991d6aaf23b13a924f94e6c10a88386fa"
+      - W/"2238c93ae4bbd1637a048da56280c1e2ebf55cd3"
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:38 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -196,7 +239,7 @@ http_interactions:
       Content-Length:
       - '3285'
       Date:
-      - Wed, 04 Oct 2017 17:22:38 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
     body:
       encoding: UTF-8
       string: |
@@ -244,26 +287,26 @@ http_interactions:
         @prefix config:  <info:fedoraconfig/> .
         @prefix dc:  <http://purl.org/dc/elements/1.1/> .
 
-        <http://fedora:8080/rest/willow_test/15/77/51/7d/1577517d-f8ba-4ceb-a066-7ec0210dd458>
+        <http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a>
                 rdf:type               fedora:Container ;
                 rdf:type               fedora:Resource ;
                 fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
                 fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
-                fedora:created         "2017-10-04T17:22:38.756Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-                fedora:lastModified    "2017-10-04T17:22:38.756Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:created         "2017-10-04T17:22:28.021Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:lastModified    "2017-10-04T17:22:28.021Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
                 ns001:hasModel         "Hydra::AccessControl"^^<http://www.w3.org/2001/XMLSchema#string> ;
                 rdf:type               ldp:RDFSource ;
                 rdf:type               ldp:Container ;
                 fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
                 fedora:hasParent       <http://fedora:8080/rest/willow_test> .
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:38 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:28 GMT
 - request:
     method: post
     uri: http://solr:8983/solr/willow_test/update?softCommit=true&wt=json
     body:
       encoding: UTF-8
-      string: '[{"system_create_dtsi":"2017-10-04T17:22:38Z","system_modified_dtsi":"2017-10-04T17:22:38Z","has_model_ssim":"Hydra::AccessControl","id":"1577517d-f8ba-4ceb-a066-7ec0210dd458"}]'
+      string: '[{"system_create_dtsi":"2017-10-04T17:22:28Z","system_modified_dtsi":"2017-10-04T17:22:28Z","has_model_ssim":"Hydra::AccessControl","id":"1e7f8fb3-17dd-42fd-a500-e57203cf7d8a"}]'
     headers:
       User-Agent:
       - Faraday v0.12.2
@@ -288,10 +331,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:38 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:28 GMT
 - request:
     method: get
-    uri: http://fedora:8080/rest/willow_test/15/77/51/7d/1577517d-f8ba-4ceb-a066-7ec0210dd458
+    uri: http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a
     body:
       encoding: US-ASCII
       string: ''
@@ -312,9 +355,9 @@ http_interactions:
       message: ''
     headers:
       Etag:
-      - W/"3984243991d6aaf23b13a924f94e6c10a88386fa"
+      - W/"2238c93ae4bbd1637a048da56280c1e2ebf55cd3"
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:38 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -335,7 +378,7 @@ http_interactions:
       Content-Length:
       - '3285'
       Date:
-      - Wed, 04 Oct 2017 17:22:38 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
     body:
       encoding: UTF-8
       string: |
@@ -383,18 +426,18 @@ http_interactions:
         @prefix config:  <info:fedoraconfig/> .
         @prefix dc:  <http://purl.org/dc/elements/1.1/> .
 
-        <http://fedora:8080/rest/willow_test/15/77/51/7d/1577517d-f8ba-4ceb-a066-7ec0210dd458>
+        <http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a>
                 rdf:type               fedora:Container ;
                 rdf:type               fedora:Resource ;
                 fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
                 fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
-                fedora:created         "2017-10-04T17:22:38.756Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-                fedora:lastModified    "2017-10-04T17:22:38.756Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:created         "2017-10-04T17:22:28.021Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:lastModified    "2017-10-04T17:22:28.021Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
                 ns001:hasModel         "Hydra::AccessControl"^^<http://www.w3.org/2001/XMLSchema#string> ;
                 rdf:type               ldp:RDFSource ;
                 rdf:type               ldp:Container ;
                 fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
                 fedora:hasParent       <http://fedora:8080/rest/willow_test> .
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:38 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:28 GMT
 recorded_with: VCR 3.0.3

--- a/willow/spec/fixtures/vcr/Create_a_Image/a_logged_in_user/1_1_1.yml
+++ b/willow/spec/fixtures/vcr/Create_a_Image/a_logged_in_user/1_1_1.yml
@@ -19,23 +19,23 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:38 GMT
+      - Wed, 04 Oct 2017 17:18:10 GMT
       Etag:
-      - '"NDUwMDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"MTkwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
       - '1976'
     body:
       encoding: UTF-8
-      string: '{"responseHeader":{"status":0,"QTime":1,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["{!terms
+      string: '{"responseHeader":{"status":0,"QTime":2,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["{!terms
         f=id}","{!terms f=has_model_ssim}AdminSet"],"f.rating_sim.facet.limit":"6","f.creator_sim.facet.limit":"6","f.member_of_collections_ssim.facet.limit":"6","f.contributor_sim.facet.limit":"6","f.subject_nested_sim.facet.limit":"6","f.organisation_nested_sim.facet.limit":"6","qf":"title_tesim
         description_tesim creator_tesim keyword_tesim","f.based_near_label_sim.facet.limit":"6","f.category_sim.facet.limit":"6","wt":"json","f.keyword_sim.facet.limit":"6","facet.field":["human_readable_type_sim","resource_type_sim","creator_sim","creator_nested_sim","contributor_sim","keyword_sim","subject_sim","subject_nested_sim","language_sim","based_near_label_sim","publisher_sim","funder_sim","tagged_version_sim","file_format_sim","member_of_collections_ssim","rating_sim","category_sim","rights_holder_sim","organisation_nested_sim","generic_type_sim"],"qt":"search","f.tagged_version_sim.facet.limit":"6","f.publisher_sim.facet.limit":"6","sort":"score
         desc, system_create_dtsi desc","rows":"100","f.human_readable_type_sim.facet.limit":"6","f.creator_nested_sim.facet.limit":"6","f.funder_sim.facet.limit":"6","facet":"true","f.subject_sim.facet.limit":"6"}},"response":{"numFound":0,"start":0,"maxScore":0.0,"docs":[]},"facet_counts":{"facet_queries":{},"facet_fields":{"human_readable_type_sim":[],"resource_type_sim":[],"creator_sim":[],"creator_nested_sim":[],"contributor_sim":[],"keyword_sim":[],"subject_sim":[],"subject_nested_sim":[],"language_sim":[],"based_near_label_sim":[],"publisher_sim":[],"funder_sim":[],"tagged_version_sim":[],"file_format_sim":[],"member_of_collections_ssim":[],"rating_sim":[],"category_sim":[],"rights_holder_sim":[],"organisation_nested_sim":[],"generic_type_sim":[]},"facet_ranges":{},"facet_intervals":{},"facet_heatmaps":{}}}
 
 '
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:39 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:25 GMT
 - request:
     method: get
     uri: http://solr:8983/solr/willow_test/select?f.based_near_label_sim.facet.limit=6&f.category_sim.facet.limit=6&f.contributor_sim.facet.limit=6&f.creator_nested_sim.facet.limit=6&f.creator_sim.facet.limit=6&f.file_format_sim.facet.limit=6&f.funder_sim.facet.limit=6&f.human_readable_type_sim.facet.limit=6&f.keyword_sim.facet.limit=6&f.language_sim.facet.limit=6&f.member_of_collections_ssim.facet.limit=6&f.organisation_nested_sim.facet.limit=6&f.publisher_sim.facet.limit=6&f.rating_sim.facet.limit=6&f.resource_type_sim.facet.limit=6&f.rights_holder_sim.facet.limit=6&f.subject_nested_sim.facet.limit=6&f.subject_sim.facet.limit=6&f.tagged_version_sim.facet.limit=6&facet=true&facet.field=generic_type_sim&fq=%7B!terms%20f=has_model_ssim%7DAdminSet&qf=title_tesim%20description_tesim%20creator_tesim%20keyword_tesim&qt=search&rows=100&sort=score%20desc,%20system_create_dtsi%20desc&wt=json
@@ -55,23 +55,23 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:38 GMT
+      - Wed, 04 Oct 2017 17:18:10 GMT
       Etag:
-      - '"NDUwMDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"MTkwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
       - '1976'
     body:
       encoding: UTF-8
-      string: '{"responseHeader":{"status":0,"QTime":9,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["{!terms
+      string: '{"responseHeader":{"status":0,"QTime":3,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["{!terms
         f=id}","{!terms f=has_model_ssim}AdminSet"],"f.rating_sim.facet.limit":"6","f.creator_sim.facet.limit":"6","f.member_of_collections_ssim.facet.limit":"6","f.contributor_sim.facet.limit":"6","f.subject_nested_sim.facet.limit":"6","f.organisation_nested_sim.facet.limit":"6","qf":"title_tesim
         description_tesim creator_tesim keyword_tesim","f.based_near_label_sim.facet.limit":"6","f.category_sim.facet.limit":"6","wt":"json","f.keyword_sim.facet.limit":"6","facet.field":["human_readable_type_sim","resource_type_sim","creator_sim","creator_nested_sim","contributor_sim","keyword_sim","subject_sim","subject_nested_sim","language_sim","based_near_label_sim","publisher_sim","funder_sim","tagged_version_sim","file_format_sim","member_of_collections_ssim","rating_sim","category_sim","rights_holder_sim","organisation_nested_sim","generic_type_sim"],"qt":"search","f.tagged_version_sim.facet.limit":"6","f.publisher_sim.facet.limit":"6","sort":"score
         desc, system_create_dtsi desc","rows":"100","f.human_readable_type_sim.facet.limit":"6","f.creator_nested_sim.facet.limit":"6","f.funder_sim.facet.limit":"6","facet":"true","f.subject_sim.facet.limit":"6"}},"response":{"numFound":0,"start":0,"maxScore":0.0,"docs":[]},"facet_counts":{"facet_queries":{},"facet_fields":{"human_readable_type_sim":[],"resource_type_sim":[],"creator_sim":[],"creator_nested_sim":[],"contributor_sim":[],"keyword_sim":[],"subject_sim":[],"subject_nested_sim":[],"language_sim":[],"based_near_label_sim":[],"publisher_sim":[],"funder_sim":[],"tagged_version_sim":[],"file_format_sim":[],"member_of_collections_ssim":[],"rating_sim":[],"category_sim":[],"rights_holder_sim":[],"organisation_nested_sim":[],"generic_type_sim":[]},"facet_ranges":{},"facet_intervals":{},"facet_heatmaps":{}}}
 
 '
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:39 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:27 GMT
 - request:
     method: get
     uri: http://solr:8983/solr/willow_test/select?f.based_near_label_sim.facet.limit=6&f.category_sim.facet.limit=6&f.contributor_sim.facet.limit=6&f.creator_nested_sim.facet.limit=6&f.creator_sim.facet.limit=6&f.file_format_sim.facet.limit=6&f.funder_sim.facet.limit=6&f.human_readable_type_sim.facet.limit=6&f.keyword_sim.facet.limit=6&f.language_sim.facet.limit=6&f.member_of_collections_ssim.facet.limit=6&f.organisation_nested_sim.facet.limit=6&f.publisher_sim.facet.limit=6&f.rating_sim.facet.limit=6&f.resource_type_sim.facet.limit=6&f.rights_holder_sim.facet.limit=6&f.subject_nested_sim.facet.limit=6&f.subject_sim.facet.limit=6&f.tagged_version_sim.facet.limit=6&facet=true&facet.field=generic_type_sim&fq=-suppressed_bsi:true&qf=title_tesim%20description_tesim%20creator_tesim%20keyword_tesim&qt=search&rows=100&sort=title_si%20asc&wt=json
@@ -91,24 +91,67 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:38 GMT
+      - Wed, 04 Oct 2017 17:18:10 GMT
       Etag:
-      - '"NDUwMDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"MTkwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
       - '2101'
     body:
       encoding: UTF-8
-      string: '{"responseHeader":{"status":0,"QTime":3,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["({!terms
-        f=edit_access_group_ssim}public,registered) OR edit_access_person_ssim:email\\-176251334261768965653214169285713529951@test.com","{!terms
+      string: '{"responseHeader":{"status":0,"QTime":4,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["({!terms
+        f=edit_access_group_ssim}public,registered) OR edit_access_person_ssim:email\\-114319035827911355670370217882408880284@test.com","{!terms
         f=has_model_ssim}Collection","-suppressed_bsi:true"],"f.rating_sim.facet.limit":"6","f.creator_sim.facet.limit":"6","f.member_of_collections_ssim.facet.limit":"6","f.contributor_sim.facet.limit":"6","f.subject_nested_sim.facet.limit":"6","f.organisation_nested_sim.facet.limit":"6","qf":"title_tesim
         description_tesim creator_tesim keyword_tesim","f.based_near_label_sim.facet.limit":"6","f.category_sim.facet.limit":"6","wt":"json","f.keyword_sim.facet.limit":"6","facet.field":["human_readable_type_sim","resource_type_sim","creator_sim","creator_nested_sim","contributor_sim","keyword_sim","subject_sim","subject_nested_sim","language_sim","based_near_label_sim","publisher_sim","funder_sim","tagged_version_sim","file_format_sim","member_of_collections_ssim","rating_sim","category_sim","rights_holder_sim","organisation_nested_sim","generic_type_sim"],"qt":"search","f.tagged_version_sim.facet.limit":"6","f.publisher_sim.facet.limit":"6","sort":"title_si
         asc","rows":"100","f.human_readable_type_sim.facet.limit":"6","f.creator_nested_sim.facet.limit":"6","f.funder_sim.facet.limit":"6","facet":"true","f.subject_sim.facet.limit":"6"}},"response":{"numFound":0,"start":0,"maxScore":0.0,"docs":[]},"facet_counts":{"facet_queries":{},"facet_fields":{"human_readable_type_sim":[],"resource_type_sim":[],"creator_sim":[],"creator_nested_sim":[],"contributor_sim":[],"keyword_sim":[],"subject_sim":[],"subject_nested_sim":[],"language_sim":[],"based_near_label_sim":[],"publisher_sim":[],"funder_sim":[],"tagged_version_sim":[],"file_format_sim":[],"member_of_collections_ssim":[],"rating_sim":[],"category_sim":[],"rights_holder_sim":[],"organisation_nested_sim":[],"generic_type_sim":[]},"facet_ranges":{},"facet_intervals":{},"facet_heatmaps":{}}}
 
 '
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:39 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:27 GMT
+- request:
+    method: head
+    uri: http://fedora:8080/rest/willow_test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Etag:
+      - W/"f35e0ddcf5120829eeccebcd791907adcf2ef49b"
+      Last-Modified:
+      - Wed, 04 Oct 2017 17:18:09 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Content-Type:
+      - application/x-turtle
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 04 Oct 2017 17:22:27 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 04 Oct 2017 17:22:27 GMT
 - request:
     method: post
     uri: http://fedora:8080/rest/willow_test
@@ -134,25 +177,25 @@ http_interactions:
       message: ''
     headers:
       Etag:
-      - W/"dc9d2bce3549e5170e2cbf03a69730e71dcb50c4"
+      - W/"2238c93ae4bbd1637a048da56280c1e2ebf55cd3"
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:39 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
       Location:
-      - http://fedora:8080/rest/willow_test/e0/45/08/45/e0450845-34b7-4843-97f5-f464d01060a5
+      - http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a
       Content-Type:
       - text/plain
       Content-Length:
       - '84'
       Date:
-      - Wed, 04 Oct 2017 17:22:39 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
     body:
       encoding: UTF-8
-      string: http://fedora:8080/rest/willow_test/e0/45/08/45/e0450845-34b7-4843-97f5-f464d01060a5
+      string: http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:39 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:28 GMT
 - request:
     method: get
-    uri: http://fedora:8080/rest/willow_test/e0/45/08/45/e0450845-34b7-4843-97f5-f464d01060a5
+    uri: http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a
     body:
       encoding: US-ASCII
       string: ''
@@ -173,9 +216,9 @@ http_interactions:
       message: ''
     headers:
       Etag:
-      - W/"dc9d2bce3549e5170e2cbf03a69730e71dcb50c4"
+      - W/"2238c93ae4bbd1637a048da56280c1e2ebf55cd3"
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:39 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -196,7 +239,7 @@ http_interactions:
       Content-Length:
       - '3285'
       Date:
-      - Wed, 04 Oct 2017 17:22:39 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
     body:
       encoding: UTF-8
       string: |
@@ -244,26 +287,26 @@ http_interactions:
         @prefix config:  <info:fedoraconfig/> .
         @prefix dc:  <http://purl.org/dc/elements/1.1/> .
 
-        <http://fedora:8080/rest/willow_test/e0/45/08/45/e0450845-34b7-4843-97f5-f464d01060a5>
+        <http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a>
                 rdf:type               fedora:Container ;
                 rdf:type               fedora:Resource ;
                 fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
                 fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
-                fedora:created         "2017-10-04T17:22:39.856Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-                fedora:lastModified    "2017-10-04T17:22:39.856Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:created         "2017-10-04T17:22:28.021Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:lastModified    "2017-10-04T17:22:28.021Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
                 ns001:hasModel         "Hydra::AccessControl"^^<http://www.w3.org/2001/XMLSchema#string> ;
                 rdf:type               ldp:RDFSource ;
                 rdf:type               ldp:Container ;
                 fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
                 fedora:hasParent       <http://fedora:8080/rest/willow_test> .
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:39 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:28 GMT
 - request:
     method: post
     uri: http://solr:8983/solr/willow_test/update?softCommit=true&wt=json
     body:
       encoding: UTF-8
-      string: '[{"system_create_dtsi":"2017-10-04T17:22:39Z","system_modified_dtsi":"2017-10-04T17:22:39Z","has_model_ssim":"Hydra::AccessControl","id":"e0450845-34b7-4843-97f5-f464d01060a5"}]'
+      string: '[{"system_create_dtsi":"2017-10-04T17:22:28Z","system_modified_dtsi":"2017-10-04T17:22:28Z","has_model_ssim":"Hydra::AccessControl","id":"1e7f8fb3-17dd-42fd-a500-e57203cf7d8a"}]'
     headers:
       User-Agent:
       - Faraday v0.12.2
@@ -284,14 +327,14 @@ http_interactions:
       - '43'
     body:
       encoding: UTF-8
-      string: '{"responseHeader":{"status":0,"QTime":13}}
+      string: '{"responseHeader":{"status":0,"QTime":18}}
 
 '
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:39 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:28 GMT
 - request:
     method: get
-    uri: http://fedora:8080/rest/willow_test/e0/45/08/45/e0450845-34b7-4843-97f5-f464d01060a5
+    uri: http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a
     body:
       encoding: US-ASCII
       string: ''
@@ -312,9 +355,9 @@ http_interactions:
       message: ''
     headers:
       Etag:
-      - W/"dc9d2bce3549e5170e2cbf03a69730e71dcb50c4"
+      - W/"2238c93ae4bbd1637a048da56280c1e2ebf55cd3"
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:39 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -335,7 +378,7 @@ http_interactions:
       Content-Length:
       - '3285'
       Date:
-      - Wed, 04 Oct 2017 17:22:39 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
     body:
       encoding: UTF-8
       string: |
@@ -383,18 +426,18 @@ http_interactions:
         @prefix config:  <info:fedoraconfig/> .
         @prefix dc:  <http://purl.org/dc/elements/1.1/> .
 
-        <http://fedora:8080/rest/willow_test/e0/45/08/45/e0450845-34b7-4843-97f5-f464d01060a5>
+        <http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a>
                 rdf:type               fedora:Container ;
                 rdf:type               fedora:Resource ;
                 fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
                 fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
-                fedora:created         "2017-10-04T17:22:39.856Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-                fedora:lastModified    "2017-10-04T17:22:39.856Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:created         "2017-10-04T17:22:28.021Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:lastModified    "2017-10-04T17:22:28.021Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
                 ns001:hasModel         "Hydra::AccessControl"^^<http://www.w3.org/2001/XMLSchema#string> ;
                 rdf:type               ldp:RDFSource ;
                 rdf:type               ldp:Container ;
                 fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
                 fedora:hasParent       <http://fedora:8080/rest/willow_test> .
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:39 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:28 GMT
 recorded_with: VCR 3.0.3

--- a/willow/spec/fixtures/vcr/Create_a_RdssDataset/a_logged_in_user/1_1_1.yml
+++ b/willow/spec/fixtures/vcr/Create_a_RdssDataset/a_logged_in_user/1_1_1.yml
@@ -19,23 +19,23 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:39 GMT
+      - Wed, 04 Oct 2017 17:18:10 GMT
       Etag:
-      - '"MjUwMDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"MTkwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
       - '1976'
     body:
       encoding: UTF-8
-      string: '{"responseHeader":{"status":0,"QTime":1,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["{!terms
+      string: '{"responseHeader":{"status":0,"QTime":2,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["{!terms
         f=id}","{!terms f=has_model_ssim}AdminSet"],"f.rating_sim.facet.limit":"6","f.creator_sim.facet.limit":"6","f.member_of_collections_ssim.facet.limit":"6","f.contributor_sim.facet.limit":"6","f.subject_nested_sim.facet.limit":"6","f.organisation_nested_sim.facet.limit":"6","qf":"title_tesim
         description_tesim creator_tesim keyword_tesim","f.based_near_label_sim.facet.limit":"6","f.category_sim.facet.limit":"6","wt":"json","f.keyword_sim.facet.limit":"6","facet.field":["human_readable_type_sim","resource_type_sim","creator_sim","creator_nested_sim","contributor_sim","keyword_sim","subject_sim","subject_nested_sim","language_sim","based_near_label_sim","publisher_sim","funder_sim","tagged_version_sim","file_format_sim","member_of_collections_ssim","rating_sim","category_sim","rights_holder_sim","organisation_nested_sim","generic_type_sim"],"qt":"search","f.tagged_version_sim.facet.limit":"6","f.publisher_sim.facet.limit":"6","sort":"score
         desc, system_create_dtsi desc","rows":"100","f.human_readable_type_sim.facet.limit":"6","f.creator_nested_sim.facet.limit":"6","f.funder_sim.facet.limit":"6","facet":"true","f.subject_sim.facet.limit":"6"}},"response":{"numFound":0,"start":0,"maxScore":0.0,"docs":[]},"facet_counts":{"facet_queries":{},"facet_fields":{"human_readable_type_sim":[],"resource_type_sim":[],"creator_sim":[],"creator_nested_sim":[],"contributor_sim":[],"keyword_sim":[],"subject_sim":[],"subject_nested_sim":[],"language_sim":[],"based_near_label_sim":[],"publisher_sim":[],"funder_sim":[],"tagged_version_sim":[],"file_format_sim":[],"member_of_collections_ssim":[],"rating_sim":[],"category_sim":[],"rights_holder_sim":[],"organisation_nested_sim":[],"generic_type_sim":[]},"facet_ranges":{},"facet_intervals":{},"facet_heatmaps":{}}}
 
 '
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:40 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:25 GMT
 - request:
     method: get
     uri: http://solr:8983/solr/willow_test/select?f.based_near_label_sim.facet.limit=6&f.category_sim.facet.limit=6&f.contributor_sim.facet.limit=6&f.creator_nested_sim.facet.limit=6&f.creator_sim.facet.limit=6&f.file_format_sim.facet.limit=6&f.funder_sim.facet.limit=6&f.human_readable_type_sim.facet.limit=6&f.keyword_sim.facet.limit=6&f.language_sim.facet.limit=6&f.member_of_collections_ssim.facet.limit=6&f.organisation_nested_sim.facet.limit=6&f.publisher_sim.facet.limit=6&f.rating_sim.facet.limit=6&f.resource_type_sim.facet.limit=6&f.rights_holder_sim.facet.limit=6&f.subject_nested_sim.facet.limit=6&f.subject_sim.facet.limit=6&f.tagged_version_sim.facet.limit=6&facet=true&facet.field=generic_type_sim&fq=%7B!terms%20f=has_model_ssim%7DAdminSet&qf=title_tesim%20description_tesim%20creator_tesim%20keyword_tesim&qt=search&rows=100&sort=score%20desc,%20system_create_dtsi%20desc&wt=json
@@ -55,23 +55,23 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:39 GMT
+      - Wed, 04 Oct 2017 17:18:10 GMT
       Etag:
-      - '"MjUwMDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"MTkwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
       - '1976'
     body:
       encoding: UTF-8
-      string: '{"responseHeader":{"status":0,"QTime":2,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["{!terms
+      string: '{"responseHeader":{"status":0,"QTime":3,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["{!terms
         f=id}","{!terms f=has_model_ssim}AdminSet"],"f.rating_sim.facet.limit":"6","f.creator_sim.facet.limit":"6","f.member_of_collections_ssim.facet.limit":"6","f.contributor_sim.facet.limit":"6","f.subject_nested_sim.facet.limit":"6","f.organisation_nested_sim.facet.limit":"6","qf":"title_tesim
         description_tesim creator_tesim keyword_tesim","f.based_near_label_sim.facet.limit":"6","f.category_sim.facet.limit":"6","wt":"json","f.keyword_sim.facet.limit":"6","facet.field":["human_readable_type_sim","resource_type_sim","creator_sim","creator_nested_sim","contributor_sim","keyword_sim","subject_sim","subject_nested_sim","language_sim","based_near_label_sim","publisher_sim","funder_sim","tagged_version_sim","file_format_sim","member_of_collections_ssim","rating_sim","category_sim","rights_holder_sim","organisation_nested_sim","generic_type_sim"],"qt":"search","f.tagged_version_sim.facet.limit":"6","f.publisher_sim.facet.limit":"6","sort":"score
         desc, system_create_dtsi desc","rows":"100","f.human_readable_type_sim.facet.limit":"6","f.creator_nested_sim.facet.limit":"6","f.funder_sim.facet.limit":"6","facet":"true","f.subject_sim.facet.limit":"6"}},"response":{"numFound":0,"start":0,"maxScore":0.0,"docs":[]},"facet_counts":{"facet_queries":{},"facet_fields":{"human_readable_type_sim":[],"resource_type_sim":[],"creator_sim":[],"creator_nested_sim":[],"contributor_sim":[],"keyword_sim":[],"subject_sim":[],"subject_nested_sim":[],"language_sim":[],"based_near_label_sim":[],"publisher_sim":[],"funder_sim":[],"tagged_version_sim":[],"file_format_sim":[],"member_of_collections_ssim":[],"rating_sim":[],"category_sim":[],"rights_holder_sim":[],"organisation_nested_sim":[],"generic_type_sim":[]},"facet_ranges":{},"facet_intervals":{},"facet_heatmaps":{}}}
 
 '
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:40 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:27 GMT
 - request:
     method: get
     uri: http://solr:8983/solr/willow_test/select?f.based_near_label_sim.facet.limit=6&f.category_sim.facet.limit=6&f.contributor_sim.facet.limit=6&f.creator_nested_sim.facet.limit=6&f.creator_sim.facet.limit=6&f.file_format_sim.facet.limit=6&f.funder_sim.facet.limit=6&f.human_readable_type_sim.facet.limit=6&f.keyword_sim.facet.limit=6&f.language_sim.facet.limit=6&f.member_of_collections_ssim.facet.limit=6&f.organisation_nested_sim.facet.limit=6&f.publisher_sim.facet.limit=6&f.rating_sim.facet.limit=6&f.resource_type_sim.facet.limit=6&f.rights_holder_sim.facet.limit=6&f.subject_nested_sim.facet.limit=6&f.subject_sim.facet.limit=6&f.tagged_version_sim.facet.limit=6&facet=true&facet.field=generic_type_sim&fq=-suppressed_bsi:true&qf=title_tesim%20description_tesim%20creator_tesim%20keyword_tesim&qt=search&rows=100&sort=title_si%20asc&wt=json
@@ -91,24 +91,67 @@ http_interactions:
       message: OK
     headers:
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:39 GMT
+      - Wed, 04 Oct 2017 17:18:10 GMT
       Etag:
-      - '"MjUwMDAwMDAwMDAwMDAwMFNvbHI="'
+      - '"MTkwMDAwMDAwMDAwMDAwMFNvbHI="'
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
       - '2101'
     body:
       encoding: UTF-8
-      string: '{"responseHeader":{"status":0,"QTime":2,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["({!terms
-        f=edit_access_group_ssim}public,registered) OR edit_access_person_ssim:email\\-246364898611404938471496974549197521477@test.com","{!terms
+      string: '{"responseHeader":{"status":0,"QTime":4,"params":{"f.language_sim.facet.limit":"6","f.rights_holder_sim.facet.limit":"6","f.file_format_sim.facet.limit":"6","f.resource_type_sim.facet.limit":"6","fq":["({!terms
+        f=edit_access_group_ssim}public,registered) OR edit_access_person_ssim:email\\-114319035827911355670370217882408880284@test.com","{!terms
         f=has_model_ssim}Collection","-suppressed_bsi:true"],"f.rating_sim.facet.limit":"6","f.creator_sim.facet.limit":"6","f.member_of_collections_ssim.facet.limit":"6","f.contributor_sim.facet.limit":"6","f.subject_nested_sim.facet.limit":"6","f.organisation_nested_sim.facet.limit":"6","qf":"title_tesim
         description_tesim creator_tesim keyword_tesim","f.based_near_label_sim.facet.limit":"6","f.category_sim.facet.limit":"6","wt":"json","f.keyword_sim.facet.limit":"6","facet.field":["human_readable_type_sim","resource_type_sim","creator_sim","creator_nested_sim","contributor_sim","keyword_sim","subject_sim","subject_nested_sim","language_sim","based_near_label_sim","publisher_sim","funder_sim","tagged_version_sim","file_format_sim","member_of_collections_ssim","rating_sim","category_sim","rights_holder_sim","organisation_nested_sim","generic_type_sim"],"qt":"search","f.tagged_version_sim.facet.limit":"6","f.publisher_sim.facet.limit":"6","sort":"title_si
         asc","rows":"100","f.human_readable_type_sim.facet.limit":"6","f.creator_nested_sim.facet.limit":"6","f.funder_sim.facet.limit":"6","facet":"true","f.subject_sim.facet.limit":"6"}},"response":{"numFound":0,"start":0,"maxScore":0.0,"docs":[]},"facet_counts":{"facet_queries":{},"facet_fields":{"human_readable_type_sim":[],"resource_type_sim":[],"creator_sim":[],"creator_nested_sim":[],"contributor_sim":[],"keyword_sim":[],"subject_sim":[],"subject_nested_sim":[],"language_sim":[],"based_near_label_sim":[],"publisher_sim":[],"funder_sim":[],"tagged_version_sim":[],"file_format_sim":[],"member_of_collections_ssim":[],"rating_sim":[],"category_sim":[],"rights_holder_sim":[],"organisation_nested_sim":[],"generic_type_sim":[]},"facet_ranges":{},"facet_intervals":{},"facet_heatmaps":{}}}
 
 '
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:40 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:27 GMT
+- request:
+    method: head
+    uri: http://fedora:8080/rest/willow_test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Etag:
+      - W/"f35e0ddcf5120829eeccebcd791907adcf2ef49b"
+      Last-Modified:
+      - Wed, 04 Oct 2017 17:18:09 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Content-Type:
+      - application/x-turtle
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 04 Oct 2017 17:22:27 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 04 Oct 2017 17:22:27 GMT
 - request:
     method: post
     uri: http://fedora:8080/rest/willow_test
@@ -134,25 +177,25 @@ http_interactions:
       message: ''
     headers:
       Etag:
-      - W/"6badff3846f81e2aa85310739aeec39d77f19cf0"
+      - W/"2238c93ae4bbd1637a048da56280c1e2ebf55cd3"
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:41 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
       Location:
-      - http://fedora:8080/rest/willow_test/05/22/27/58/05222758-d7ca-4d28-8283-4bc0fc38e3fe
+      - http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a
       Content-Type:
       - text/plain
       Content-Length:
       - '84'
       Date:
-      - Wed, 04 Oct 2017 17:22:41 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
     body:
       encoding: UTF-8
-      string: http://fedora:8080/rest/willow_test/05/22/27/58/05222758-d7ca-4d28-8283-4bc0fc38e3fe
+      string: http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:41 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:28 GMT
 - request:
     method: get
-    uri: http://fedora:8080/rest/willow_test/05/22/27/58/05222758-d7ca-4d28-8283-4bc0fc38e3fe
+    uri: http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a
     body:
       encoding: US-ASCII
       string: ''
@@ -173,9 +216,9 @@ http_interactions:
       message: ''
     headers:
       Etag:
-      - W/"6badff3846f81e2aa85310739aeec39d77f19cf0"
+      - W/"2238c93ae4bbd1637a048da56280c1e2ebf55cd3"
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:41 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -196,7 +239,7 @@ http_interactions:
       Content-Length:
       - '3285'
       Date:
-      - Wed, 04 Oct 2017 17:22:41 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
     body:
       encoding: UTF-8
       string: |
@@ -244,26 +287,26 @@ http_interactions:
         @prefix config:  <info:fedoraconfig/> .
         @prefix dc:  <http://purl.org/dc/elements/1.1/> .
 
-        <http://fedora:8080/rest/willow_test/05/22/27/58/05222758-d7ca-4d28-8283-4bc0fc38e3fe>
+        <http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a>
                 rdf:type               fedora:Container ;
                 rdf:type               fedora:Resource ;
                 fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
                 fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
-                fedora:created         "2017-10-04T17:22:41.118Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-                fedora:lastModified    "2017-10-04T17:22:41.118Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:created         "2017-10-04T17:22:28.021Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:lastModified    "2017-10-04T17:22:28.021Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
                 ns001:hasModel         "Hydra::AccessControl"^^<http://www.w3.org/2001/XMLSchema#string> ;
                 rdf:type               ldp:RDFSource ;
                 rdf:type               ldp:Container ;
                 fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
                 fedora:hasParent       <http://fedora:8080/rest/willow_test> .
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:41 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:28 GMT
 - request:
     method: post
     uri: http://solr:8983/solr/willow_test/update?softCommit=true&wt=json
     body:
       encoding: UTF-8
-      string: '[{"system_create_dtsi":"2017-10-04T17:22:41Z","system_modified_dtsi":"2017-10-04T17:22:41Z","has_model_ssim":"Hydra::AccessControl","id":"05222758-d7ca-4d28-8283-4bc0fc38e3fe"}]'
+      string: '[{"system_create_dtsi":"2017-10-04T17:22:28Z","system_modified_dtsi":"2017-10-04T17:22:28Z","has_model_ssim":"Hydra::AccessControl","id":"1e7f8fb3-17dd-42fd-a500-e57203cf7d8a"}]'
     headers:
       User-Agent:
       - Faraday v0.12.2
@@ -284,14 +327,14 @@ http_interactions:
       - '43'
     body:
       encoding: UTF-8
-      string: '{"responseHeader":{"status":0,"QTime":14}}
+      string: '{"responseHeader":{"status":0,"QTime":18}}
 
 '
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:41 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:28 GMT
 - request:
     method: get
-    uri: http://fedora:8080/rest/willow_test/05/22/27/58/05222758-d7ca-4d28-8283-4bc0fc38e3fe
+    uri: http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a
     body:
       encoding: US-ASCII
       string: ''
@@ -312,9 +355,9 @@ http_interactions:
       message: ''
     headers:
       Etag:
-      - W/"6badff3846f81e2aa85310739aeec39d77f19cf0"
+      - W/"2238c93ae4bbd1637a048da56280c1e2ebf55cd3"
       Last-Modified:
-      - Wed, 04 Oct 2017 17:22:41 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
       Link:
       - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
       - <http://www.w3.org/ns/ldp#Container>;rel="type"
@@ -335,7 +378,7 @@ http_interactions:
       Content-Length:
       - '3285'
       Date:
-      - Wed, 04 Oct 2017 17:22:41 GMT
+      - Wed, 04 Oct 2017 17:22:28 GMT
     body:
       encoding: UTF-8
       string: |
@@ -383,18 +426,18 @@ http_interactions:
         @prefix config:  <info:fedoraconfig/> .
         @prefix dc:  <http://purl.org/dc/elements/1.1/> .
 
-        <http://fedora:8080/rest/willow_test/05/22/27/58/05222758-d7ca-4d28-8283-4bc0fc38e3fe>
+        <http://fedora:8080/rest/willow_test/1e/7f/8f/b3/1e7f8fb3-17dd-42fd-a500-e57203cf7d8a>
                 rdf:type               fedora:Container ;
                 rdf:type               fedora:Resource ;
                 fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
                 fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
-                fedora:created         "2017-10-04T17:22:41.118Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-                fedora:lastModified    "2017-10-04T17:22:41.118Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:created         "2017-10-04T17:22:28.021Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:lastModified    "2017-10-04T17:22:28.021Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
                 ns001:hasModel         "Hydra::AccessControl"^^<http://www.w3.org/2001/XMLSchema#string> ;
                 rdf:type               ldp:RDFSource ;
                 rdf:type               ldp:Container ;
                 fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
                 fedora:hasParent       <http://fedora:8080/rest/willow_test> .
     http_version: 
-  recorded_at: Wed, 04 Oct 2017 17:22:41 GMT
+  recorded_at: Wed, 04 Oct 2017 17:22:28 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
This pull request covers the development tasks for ticket RDSS 1561. Please note that the ticket also requires the adding of documentation for the new environment variables into the configurations scripts of HEIs, which will be a seperate pull request.

This pull request adds the following functionality:

- Disables all content types by default apart from RdssDataset, by not allowing them to be registered
- Adds functionality to allow the other content types to be enabled via ENV variables
- Adds functionality to remove content types from the "new work" modal. This allows new content for a content type to be disabled whilst existing content still displays on the site
- Adds documentation to the example env file for the new variables
- Adds routes for disabled content types show view, to prevent rails errors in the case that there is existing data for a content type in the featured list section
- Updates to the Rspec tests to account for disabled content types.
- Fixes to the RSPEC tests for creation of content types to make them able to run independently of each other