### PR TITLE
Don't include license information when destroying the object for Arti…

### DIFF
--- a/willow/lib/hyrax/notifications/subscribers/build_message.rb
+++ b/willow/lib/hyrax/notifications/subscribers/build_message.rb
@@ -147,7 +147,7 @@ module Hyrax
                                } ]
                 }
               }
-            when [Dataset, Article].include?(@curation_concern_type) && @event != 'destroy_work.hyrax'
+            when [Dataset, Article].include?(@curation_concern_type) && !destroy?
               @object.license_nested.map{|r|
                 {
                     rightsStatement: r.definition.to_a,


### PR DESCRIPTION
…cles and Datasets

The line `@event != 'destroy_work.hyrax'` was added in this commit https://github.com/JiscRDSS/rdss-samvera/commit/970f68936125ce9666b41c3a7c15d00e79f3f932#diff-90346c22508f91236696690a1e1bfe6aL150 which lead to an errror

The event passed through in the case of a deletion is Hyrax::Notifications::Events::METADATA_DELETE ('MetadataDelete') and not 'destroy_work.hyrax'

If the wrong event is checked for, the following line `@object.license_nested.map` throws the following rails error.

`ActiveTriples::ParentStrategy::UnmutableParentError`

I have no idea why the change above was made, but changing the line back to `!destroy?`, which checks for the correct event, the bug dissapears.