### PR TITLE
Fix asset url for deployment

### DIFF
--- a/willow/app/assets/stylesheets/fonts.scss
+++ b/willow/app/assets/stylesheets/fonts.scss
@@ -1,9 +1,9 @@
 @font-face {
   font-family: 'stagsans-book';
-  src: url('/assets/stagsans-book.otf');
+  src: asset_url('stagsans-book.otf');
   font-weight: bold;
 }
 @font-face {
   font-family: 'stagsans';
-  src: url('/assets/stagsans-light.otf');
+  src: asset_url('stagsans-light.otf');
 }

--- a/willow/app/assets/stylesheets/rdss.scss
+++ b/willow/app/assets/stylesheets/rdss.scss
@@ -1,7 +1,7 @@
 @import 'variables';
 
 body {
-  font-family: "stagsans";
+  font-family: "stagsans", arial, helvetica;
   padding-bottom: 0;
   margin-bottom: 0;
   background: #e4e9ec;


### PR DESCRIPTION
Once deployed in a 'production' like environments, font URL's were returning a 404. Most likely as a result of the assets  url not containing a relevant MD5.