### PR TITLE
Feature/rdsssam 118 message urls internal

### DIFF
--- a/willow/lib/hyrax/notifications/subscribers/build_message.rb
+++ b/willow/lib/hyrax/notifications/subscribers/build_message.rb
@@ -268,7 +268,10 @@ module Hyrax
             @object.file_sets.each do |fs|
               files << {
                   fileUuid: fs.id,
-                  fileIdentifier: download_url(fs, host: Rails.application.routes.default_url_options[:host]),
+                  # NB: line below replaced temporarily to for https://jiscdev.atlassian.net/browse/RDSSSAM-118
+                  # override the default url host with the SAMVERA_INTERNAL_HOST environment variable if it is set
+                  # fileIdentifier: download_url(fs, host: Rails.application.routes.default_url_options[:host]),
+                  fileIdentifier: download_url(fs, host: (ENV['SAMVERA_INTERNAL_HOST'] || Rails.application.routes.default_url_options[:host])),
                   fileName: fs.first_title,
                   fileSize: fs.file_size.first.try(:to_i),
                   fileChecksum: fs.original_checksum.map{|c| {


### PR DESCRIPTION
Samvera project changes for RDSSSAM-118

This sets the domain for the downloadable resources in messages to use the internal samvera host.

I.E *.alpha.researchdata.jisc.ac.uk

The changes to set the environment variable to the correct value are in the following pull request:

https://github.com/JiscRDSS/rdss-institutional-ecs-clusters/pull/74