### PR TITLE
RDSSSAM-98 HomePage -> Contact -> 'Select an issue type' should be de…

### DIFF
--- a/willow/app/views/hyrax/contact_form/new.html.erb
+++ b/willow/app/views/hyrax/contact_form/new.html.erb
@@ -19,10 +19,8 @@
   <%= f.text_field :contact_method, class: 'hide' %>
   <div class="form-group">
     <%= f.label :category, t('hyrax.contact_form.type_label'), class: "col-sm-2 control-label" %>
-    <% issue_types = Hyrax::ContactForm.issue_types_for_locale.dup %>
-    <% issue_types.unshift([t('hyrax.contact_form.select_type'), nil]) %>
     <div class="col-sm-10">
-      <%= f.select 'category', options_for_select(issue_types), {}, {class: 'form-control', required: true } %>
+      <%= f.select 'category', options_for_select(Hyrax::ContactForm.issue_types_for_locale), { prompt: t('hyrax.contact_form.select_type')}, {class: 'form-control', required: true } %>
     </div>
   </div>
 


### PR DESCRIPTION
Converted the select to use prompt rather than duplicating the options_for_select and prefixing it with an entry which should have been non-selectable. Let Rails do the lifting on this one.