### PR TITLE
RDSSSAM-120: Jisc theme - layout/design for sign up and forgotten password

### DIFF
--- a/willow/app/assets/stylesheets/devise.scss
+++ b/willow/app/assets/stylesheets/devise.scss
@@ -1,4 +1,4 @@
-.sessions-form {
+.sessions-form, .registrations-form, .passwords-form {
   background-color: rgb(228, 233, 236);
   padding-top: 48px;
 

--- a/willow/app/views/devise/passwords/new.html.erb
+++ b/willow/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,22 @@
+<h2><%=t('devise.passwords.forgot')%></h2>
+<div class="passwords-form col-sm-8">
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: 'form-horizontal' }) do |f| %>
+    <%= devise_error_messages! %>
+    <div class="form-group">
+      <%= f.label :email, t('devise.user.username'), class: "col-sm-2 control-label" %>
+      <div class="col-sm-6">
+        <%= f.email_field :email, autofocus: true, class: 'form-control' %>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-sm-offset-2 col-sm-6 button-set">
+        <%= f.submit t('devise.passwords.reset'), class: "btn btn-primary btn-lg btn-block"%>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-sm-offset-2 col-sm-10 aux-links">
+        <%= render "devise/shared/links" %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/willow/app/views/devise/registrations/new.html.erb
+++ b/willow/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,34 @@
+<h2><%=t('devise.registrations.new')%></h2>
+<div class="registrations-form col-sm-8">
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: 'form-horizontal' }) do |f| %>
+    <%= devise_error_messages! %>
+    <div class="form-group">
+      <%= f.label :email, t('devise.user.username'), class: "col-sm-2 control-label" %>
+      <div class="col-sm-6">
+        <%= f.email_field :email, :autofocus => true, class: 'form-control' %>
+      </div>
+    </div>
+    <div class="form-group">
+      <%= f.label :password, t('devise.user.password'), class: "col-sm-2 control-label" %>
+      <div class="col-sm-6">
+        <%= f.password_field :password, class: 'form-control' %>
+      </div>
+    </div>
+    <div class="form-group">
+      <%= f.label :password, t('devise.user.password_confirmation'), class: "col-sm-2 control-label" %>
+      <div class="col-sm-6">
+        <%= f.password_field :password_confirmation, class: 'form-control' %>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-sm-offset-2 col-sm-6 button-set">
+        <%= f.submit t('devise.registrations.new'), class: "btn btn-primary btn-lg btn-block"%>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-sm-offset-2 col-sm-10 aux-links">
+        <%= render "devise/shared/links" %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/willow/config/locales/devise.en.yml
+++ b/willow/config/locales/devise.en.yml
@@ -34,12 +34,15 @@ en:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."
     passwords:
+      forgot: "Forgot your password?"
+      reset: "Send me reset password instructions"
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
       updated: "Your password has been changed successfully. You are now signed in."
       updated_not_active: "Your password has been changed successfully."
     registrations:
+      new: "Sign up"
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
       signed_up: "Welcome! You have signed up successfully."
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."


### PR DESCRIPTION
Extracted from Devise.
Adopted the revised layout html and extended the .scss into two new classes.
Stuck with form_for rather than simple_form_for to keep the pattern the same.
Added in the i18n code into devise's en.yml since simple_form not being used.