### PR TITLE
Feature/rdsssam 93

### DIFF
--- a/willow/app/assets/stylesheets/hyrax.scss
+++ b/willow/app/assets/stylesheets/hyrax.scss
@@ -13,3 +13,8 @@
 @import "blacklight_gallery/slideshow";
 @import "blacklight_gallery/osd_viewer";
 @import 'hyrax/hyrax';
+
+.actions-controls-collections {
+  display: block;
+  margin: 1em -30% 0 1em;
+}

--- a/willow/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/willow/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -1,0 +1,23 @@
+<h2 class="sr-only"><%= t('hyrax.collection.actions.header') %></h2>
+<div class="actions-controls-collections">
+  <% if can? :edit, presenter.solr_document %>
+    <%= link_to t('hyrax.collection.actions.edit.label'),
+                edit_dashboard_collection_path(presenter),
+                title: t('hyrax.collection.actions.edit.desc'),
+                class: 'btn btn-default' %>
+    <%= link_to t('hyrax.collection.actions.add_works.label'),
+                hyrax.my_works_path(add_works_to_collection: presenter.id),
+                title: t('hyrax.collection.actions.add_works.desc'),
+                class: 'btn btn-default',
+                data: { turbolinks: false } %>
+  <%end %>
+
+  <% if can? :destroy, presenter.solr_document %>
+    <%= link_to t('hyrax.collection.actions.delete.label'),
+                dashboard_collection_path(presenter),
+                title: t('hyrax.collection.actions.delete.desc'),
+                class: 'btn btn-danger',
+                data: { confirm: t('hyrax.collection.actions.delete.confirmation'),
+                        method: :delete } %>
+  <% end %>
+</div>


### PR DESCRIPTION
Extracted and overrode the hyrax deletion view. This used collection_path as opposed to dashboard_collection_path as the route to the deletion action. 
Minor tweak to the action button bounding box to prevent the delete button from wrapping to a new line.
