### PR TITLE
Feature/rdsssam 69 migration script 2nd pass

### DIFF
--- a/willow/lib/data_importer/importer.rb
+++ b/willow/lib/data_importer/importer.rb
@@ -7,12 +7,13 @@ module DataImporter
     UNKNOWN = 'UNKNOWN'.freeze
     attr_reader :hash, :collection, :bucket, :import_dir, :filter
 
-    def initialize(bucket: , region:,
+    def initialize(bucket: , region:, prefix:,
                    import_folder: 'tmp/importer', import_filter: nil,
                    import_user: nil, import_collection_id: nil,
                    import_visibility: 'open')
       @s3 = Aws::S3::Client.new(region: region)
       @bucket = bucket
+      @prefix = prefix
       @import_folder = import_folder
       @import_filter = import_filter
       @import_user = import_user
@@ -40,7 +41,7 @@ module DataImporter
         FileUtils.mkdir_p(@import_folder)
       end
 
-      @s3.list_objects_v2(bucket: @bucket).each do |response|
+      @s3.list_objects_v2(bucket: @bucket, prefix: @prefix).each do |response|
         response.contents.each do |item|
 
           # we are only interested in files

--- a/willow/lib/tasks/importer.rake
+++ b/willow/lib/tasks/importer.rake
@@ -1,9 +1,12 @@
 namespace :willow do
   desc 'Imports a JISC RDSS S3 bucket into Willow usage: willow:import["region","bucket"]'
-  task :"import", [:region,:bucket] => :environment do |task, args|
+  task :"import", [:region,:bucket,:prefix] => :environment do |task, args|
+    
+    args.with_defaults(:prefix => '/')
 
     bucket = args.bucket
     region = args.region
+    prefix = args.prefix
 
     import_folder = ENV['IMPORT_FOLDER'] || 'tmp/importer'
     import_filter = ENV['IMPORT_FILTER'] || nil
@@ -16,6 +19,7 @@ namespace :willow do
     puts " REQUIRED SETTINGS:"
     puts "   Region: #{region}"
     puts "   Bucket: #{bucket}"
+    puts "   Prefix: #{prefix}"
 
     puts " OPTIONAL SETTINGS (via ENV variables):"
     puts "   Temporary import folder (IMPORT_FOLDER): #{import_folder}"
@@ -25,7 +29,7 @@ namespace :willow do
     puts "   Visibility (IMPORT_VISIBILITY): #{import_visibility}"
 
 
-    importer = DataImporter::Importer.new(bucket: bucket, region: region,
+    importer = DataImporter::Importer.new(bucket: bucket, region: region, prefix: prefix,
                                           import_folder: import_folder, import_filter: import_filter,
                                           import_user: import_user, import_collection_id: import_collection_id,
                                           import_visibility: import_visibility)


### PR DESCRIPTION
This is somewhat more limited in scope than it was initially. Rather than provide a general purpose import script, this deals almost entirely with importing the data available from the Eprints export. There have been only a few changes, since the purpose of this PR is to allow us to re-import before Christmas and demonstrate some improvements to pilots in advance of implementing the correct RDSSCDM work type. 