### PR TITLE
Feature/rdssam 147 fixes to layout

### DIFF
--- a/willow/app/assets/stylesheets/rdss.scss
+++ b/willow/app/assets/stylesheets/rdss.scss
@@ -229,7 +229,7 @@ div.home_share_work p.text-center a{
 }
 
 div#announcement {
-  background: rgba(217, 217, 217, 0.1);
+  background: #cedadd;
 
   p {
     color: black;

--- a/willow/app/views/hyrax/homepage/_announcement.html.erb
+++ b/willow/app/views/hyrax/homepage/_announcement.html.erb
@@ -1,0 +1,3 @@
+<% if display_content_block? @announcement_text %>
+    <%= displayable_content_block @announcement_text, class: 'alert alert-info', id: 'announcement' %>
+<% end %>

--- a/willow/app/views/layouts/hyrax.html.erb
+++ b/willow/app/views/layouts/hyrax.html.erb
@@ -11,11 +11,12 @@
 <div class="image-masthead">
   <%= render '/controls' %>
 </div>
-<%= content_for(:precontainer_content) %>
+
 
 <div class="container" id="main">
   <div class="row center">
     <div class="col-sm-12 left" id="content-left">
+      <%= content_for(:precontainer_content) %>
       <div id="content-wrapper" class="container" role="main">
         <a name="skip_to_content"></a>
         <div class="searchbar-right navbar-right col-sm-12 col-md-12">


### PR DESCRIPTION
This deals with the RDSSSAM-147 where wierd layout seen on uat for RCM.

The layout break was caused by text having been enterred into the 'anouncment' field in the admin system.

I've shuffled the layout so that the announcement appears inside the white area, removed the double white border by overriding the view, and restyled accordingly. Screenshot below

![screen shot 2017-12-15 at 12 03 32](https://user-images.githubusercontent.com/25913173/34042182-56c4bd14-e193-11e7-9fa9-e878dfa311a4.png)
