### PR TITLE
Feature/rdsssam 97 terms of use boilerplate text

### DIFF
--- a/willow/app/views/hyrax/content_blocks/templates/terms.html.erb
+++ b/willow/app/views/hyrax/content_blocks/templates/terms.html.erb
@@ -1,0 +1,8 @@
+<h1>Terms of Use for <%= ApplicationController.helpers.application_name %></h1>
+
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>

--- a/willow/config/initializers/content_block_override.rb
+++ b/willow/config/initializers/content_block_override.rb
@@ -1,0 +1,17 @@
+# Overriding the default terms and conditions text in hyrax gems ContentBlock
+# The default text in the hyrax gem is hard coded and contains references to US legal terms and conditions
+# the default text returned is the result of running the erb engine on our local version of 
+# app/views/hyrax/content_blocks
+ContentBlock.instance_eval do
+  def default_terms_text
+    ERB.new(
+        IO.read(
+          Rails.root.join('app', 'views', 'hyrax', 'content_blocks', 'templates', 'terms.html.erb')
+        )
+      ).result
+  end
+
+  def bob
+    'hello'
+  end
+end

--- a/willow/config/initializers/content_block_override.rb
+++ b/willow/config/initializers/content_block_override.rb
@@ -10,8 +10,4 @@ ContentBlock.instance_eval do
         )
       ).result
   end
-
-  def bob
-    'hello'
-  end
 end


### PR DESCRIPTION
This replaces the boilerplate terms of use page with lorem ipsum, as agreed with Dom.

Unfortunately the way Hyrax implemented the boilerplate, the only way to override it was using monkeypatching.