### PR TITLE
Feature/rdsssam 166 object date using associations

### DIFF
--- a/willow/app/controllers/catalog_controller.rb
+++ b/willow/app/controllers/catalog_controller.rb
@@ -86,7 +86,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("object_description", :stored_searchable), label: I18n.t('willow.fields.object_description'), itemprop: 'object_description', if: false
     config.add_index_field solr_name("object_keywords", :stored_searchable), label: I18n.t('willow.fields.object_keywords'), itemprop: 'object_keywords' #link_to_search: solr_name("object_keywords", :facetable)
     config.add_index_field solr_name("object_category", :stored_searchable), label: I18n.t('willow.fields.object_category'), itemprop: 'object_category' #link_to_search: solr_name("object_category", :facetable)
-    
+    config.add_index_field solr_name("object_dates", :stored_searchable), label: I18n.t('willow.fields.object_dates'), itemprop: 'object_dates'
     # End of RDSS CDM additions
 
     # solr fields to be displayed in the index (search results) view
@@ -176,6 +176,9 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("rights_holder", :stored_searchable), label: I18n.t('willow.fields.rights_holder')
     config.add_show_field solr_name("organisation_nested", :displayable), label: I18n.t('willow.fields.organisation_nested')
     config.add_show_field solr_name("preservation_nested", :displayable), label: I18n.t('willow.fields.preservation_nested')
+    # RdssCdm Addtitions
+    config.add_show_field solr_name("object_dates", :displayable), label: I18n.t('willow.fields.object_dates')
+    # end of RdssCdm Addtitions
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/willow/app/forms/hyrax/rdss_cdm_form.rb
+++ b/willow/app/forms/hyrax/rdss_cdm_form.rb
@@ -41,10 +41,11 @@ module Hyrax
     def self.permitted_object_date_params
       [:id,
        :_destroy,
-       {
-         date_value: [],
-         date_type: []
-       }]
+       [
+         :date_value,
+         :date_type
+        ]
+      ]
     end
 
     def self.build_permitted_params

--- a/willow/app/forms/hyrax/rdss_cdm_form.rb
+++ b/willow/app/forms/hyrax/rdss_cdm_form.rb
@@ -5,14 +5,53 @@ module Hyrax
     self.model_class = ::RdssCdm
 
     self.terms = [
-      :title, 
+      :title,
       :object_description,
       :object_keywords,
       :object_category,
-      :object_version
+      :object_version,
+      :object_dates
     ]
     self.required_fields = [
       :title
     ]
+
+    # utility methods to allow nested fields to work with the hyrax form
+    # Taken from https://github.com/curationexperts/laevigata/
+
+    # In the view we have "fields_for :object_dates".
+    # This method is needed to make fields_for behave as an
+    # association and populate the form with the correct
+    # object_date data.
+    delegate :object_dates_attributes=, to: :model
+
+    # We need to call '.to_a' on committee_members to force it
+    # to resolve.  Otherwise in the form, the fields don't
+    # display the object_dates's type and value
+    # Instead they display something like:
+    # '#<ActiveTriples::Relation:0x007fb564969c88>'
+    def object_dates
+      model.object_dates.build if model.object_dates.blank?
+      model.object_dates.to_a
+    end
+
+    # Permitted parameters for nested attributes
+    # These need to define the incoming parameters for any nested form attributes so that
+    # strong_params permits them
+    def self.permitted_object_date_params
+      [:id,
+       :_destroy,
+       {
+         date_value: [],
+         date_type: []
+       }]
+    end
+
+    def self.build_permitted_params
+      permitted = super
+      # add in object_date attributes
+      permitted << { object_dates_attributes: permitted_object_date_params }
+      permitted
+    end
   end
 end

--- a/willow/app/indexers/rdss_cdm_indexer.rb
+++ b/willow/app/indexers/rdss_cdm_indexer.rb
@@ -5,6 +5,18 @@ class RdssCdmIndexer < Hyrax::WorkIndexer
     super.tap do |solr_doc|
       # Enter any manual indexing code here
       # if possible, indexing should be specified within the model
+
+      # index a displayable version of the object date
+      solr_doc[Solrizer.solr_name('object_dates', :displayable)] = object.object_dates.to_json
+      
+      # for each object date, index a value for the specific date type to allow sorting by the date type
+      # eg object_date_approved
+      object.object_dates.each do |d|
+        label = RdssDateTypesService.label(d.date_type) rescue nil
+        if label
+          solr_doc[Solrizer.solr_name("object_dates_#{label.downcase}", :stored_sortable)] = d.date_value
+        end
+      end
     end
   end
 end

--- a/willow/app/models/cdm/date.rb
+++ b/willow/app/models/cdm/date.rb
@@ -1,0 +1,11 @@
+module Cdm
+  # Active fedora model representing an object date for an rdss_cdm model
+  class Date < ActiveFedora::Base
+    property :date_value, predicate: ::RDF::Vocab::DC.date, multiple: false
+    property :date_type, predicate: ::RDF::Vocab::DC.description, multiple: false
+
+    # Define relationship with rdss_cdm model
+    # predicate taken from https://github.com/samvera/hydra/wiki/Lesson---Define-Relationships-Between-Objects
+    belongs_to :rdss_cdm, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf
+  end
+end

--- a/willow/app/models/concerns/rdss_extensions.rb
+++ b/willow/app/models/concerns/rdss_extensions.rb
@@ -23,6 +23,7 @@ module Concerns
     included do
       #New RDSS CSM types
       stored_searchable :title, :object_description, :object_keywords, :object_category, :object_person_role
+      displayable :object_dates
     end
 
     def solr_name(name, type)

--- a/willow/app/models/rdss_cdm.rb
+++ b/willow/app/models/rdss_cdm.rb
@@ -43,7 +43,7 @@ class RdssCdm < ActiveFedora::Base
   has_many :object_dates, class_name: 'Cdm::Date'
 
   # Accepts nested attributes declarations need to go after the property declarations, as they close off the model
-  accepts_nested_attributes_for :object_dates
+  accepts_nested_attributes_for :object_dates, allow_destroy: true
 
   
   def self.multiple?(field)

--- a/willow/app/models/rdss_cdm.rb
+++ b/willow/app/models/rdss_cdm.rb
@@ -38,6 +38,9 @@ class RdssCdm < ActiveFedora::Base
   #property :object_organisation_role
   #property :object_preservation_event
   #property :object_file
+
+  # object_date nested relationship
+  has_many :object_dates, class_name: 'Cdm::Date'
   
   def self.multiple?(field)
     # Overriding to return false for `title` (as we can't set multiple: false) 

--- a/willow/app/models/rdss_cdm.rb
+++ b/willow/app/models/rdss_cdm.rb
@@ -41,6 +41,10 @@ class RdssCdm < ActiveFedora::Base
 
   # object_date nested relationship
   has_many :object_dates, class_name: 'Cdm::Date'
+
+  # Accepts nested attributes declarations need to go after the property declarations, as they close off the model
+  accepts_nested_attributes_for :object_dates
+
   
   def self.multiple?(field)
     # Overriding to return false for `title` (as we can't set multiple: false) 

--- a/willow/app/presenters/hyrax/rdss_cdm_presenter.rb
+++ b/willow/app/presenters/hyrax/rdss_cdm_presenter.rb
@@ -2,6 +2,6 @@
 #  `rails generate hyrax:work RdssCdm`
 module Hyrax
   class RdssCdmPresenter < Hyrax::WorkShowPresenter
-    delegate :title, :object_description, :object_keywords, :object_category, to: :solr_document
+    delegate :title, :object_description, :object_keywords, :object_category, :object_dates, to: :solr_document
   end
 end

--- a/willow/app/renderers/object_dates_attribute_renderer.rb
+++ b/willow/app/renderers/object_dates_attribute_renderer.rb
@@ -1,0 +1,29 @@
+class ObjectDatesAttributeRenderer < Hyrax::Renderers::AttributeRenderer
+  private
+  # translate the json string for object date into a table of displayable dates
+  # parse the json, and create a table where each row has a cell with the date type and the date value
+  def attribute_value_to_html(value)
+    value = JSON.parse(value)
+    if not value.kind_of?(Array)
+      value = [value]
+    end
+    html = '<table class="table"><tbodby>'
+    value.each do |v|
+      label = ''
+      val = ''
+      if(type = v['date_type'])
+        label = RdssDateTypesService.label(type)
+      end
+      if(date = v['date_value'])
+        begin
+          val = Date.parse(date).to_formatted_s(:standard)
+        rescue
+          val = date
+        end
+      end
+      html += "<tr><th>#{label}</th><td>#{val}</td><tr>"
+    end
+    html += '</tbody></table>'
+    %(#{html})
+  end
+end

--- a/willow/app/views/hyrax/rdss_cdms/_attribute_rows.html.erb
+++ b/willow/app/views/hyrax/rdss_cdms/_attribute_rows.html.erb
@@ -2,3 +2,4 @@
 <%= presenter.attribute_to_html(:object_description) %>
 <%= presenter.attribute_to_html(:object_keywords) %>
 <%= presenter.attribute_to_html(:object_category) %>
+<%= presenter.attribute_to_html(:object_dates, render_as: :object_dates, label: I18n.t('willow.fields.object_dates')) %><%# the `:render_as` parameter tells the presenter to use the object_dates_attribute_renderer %> 

--- a/willow/app/views/records/edit_fields/_object_dates.html.erb
+++ b/willow/app/views/records/edit_fields/_object_dates.html.erb
@@ -11,6 +11,14 @@
         <div class="col-md-6">
           <%= od.input :date_value, label: false, input_html: {data: { provide: 'datepicker' }} %>
         </div>
+        <div class='col-md-3'>
+          <%= od.input :_destroy, as: :hidden, input_html:{ data: { destroy: true }, class: 'form-control remove-hidden', value: false} %> 
+          <button type="button" class="btn btn-link remove">
+            <span class="glyphicon glyphicon-remove"></span>
+            <span class="controls-remove-text">Remove</span>
+            <span class="sr-only"> previous <span class="controls-field-name-text"> Date</span></span>
+          </button>
+        <div>
       </div>
     </li>
   <% end %>

--- a/willow/app/views/records/edit_fields/_object_dates.html.erb
+++ b/willow/app/views/records/edit_fields/_object_dates.html.erb
@@ -1,0 +1,22 @@
+<div class="multi-nested">
+  <%# only output the label and the hint text. wrapper defined in config/initializers/simple_form_rdss.rb %>
+  <%= f.input :object_dates, wrapper: :label_and_hint_only %>
+  <ul class="listing"><%# normally added by https://github.com/samvera/hydra-editor/blob/master/app/inputs/multi_value_input.rb %>
+  <%= f.fields_for :object_dates, @form.object_dates do |od| %>
+    <li class="field-wrapper"><%# normally added by https://github.com/samvera/hydra-editor/blob/master/app/inputs/multi_value_input.rb %>
+      <div class="row">
+        <div class="col-md-3">
+          <%= od.input :date_type, collection: RdssDateTypesService.select_all_options, prompt: :translate, label: false %>
+        </div>
+        <div class="col-md-6">
+          <%= od.input :date_value, label: false, input_html: {data: { provide: 'datepicker' }} %>
+        </div>
+      </div>
+    </li>
+  <% end %>
+</ul>
+  <button type="button" class="btn btn-link add">
+    <span class="glyphicon glyphicon-plus"></span>
+    <span class="controls-add-text">Add another Date</span>
+  </button>
+</div>

--- a/willow/config/initializers/simple_form_rdss.rb
+++ b/willow/config/initializers/simple_form_rdss.rb
@@ -1,0 +1,14 @@
+SimpleForm.setup do |config|
+  # Set up a wrapper to only output the label and help text, without the input
+  # this is used by nested properties where the label for the model as a whole is desired
+  # but finer control is needed over the inputs and layout
+  # Note: this is replacing the functionality in https://github.com/samvera/hydra-editor/blob/master/app/inputs/multi_value_input.rb
+  config.wrappers :label_and_hint_only do |b|
+    b.use :html5
+    b.use :label, class: 'control-label'
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    #b.use :input # note we don't include the input
+  end
+
+end

--- a/willow/config/locales/en.yml
+++ b/willow/config/locales/en.yml
@@ -60,4 +60,5 @@ en:
       tagged_version: 'Version'
       title: 'Title'
       rdss_version: 'Version'
+      object_dates: Dates
 

--- a/willow/config/locales/rdss_cdm.en.yml
+++ b/willow/config/locales/rdss_cdm.en.yml
@@ -13,4 +13,11 @@ en:
         object_keywords: 'Keywords'
         object_category: 'Category'
         object_version: 'Version'
-
+        object_dates: 'Date'
+    hints:
+      rdss_cdm:
+        object_dates: 'The different dates relevant to the dataset.'
+    prompts:
+      rdss_cdm:
+        object_dates: 
+          date_type: 'choose type'


### PR DESCRIPTION
This pull request represents an alternative to https://github.com/JiscRDSS/rdss-samvera/pull/44 (RDSSSAM-133) that makes two changes in approach:

1. Using associated models (ActiveFedora::Base) rather than properties (ActiveFedora::Resource)

2. Using Simpleform directly in the edit view, rather than relying on the the custom inputs code.

I've also used the renderers for displaying the values on the front end, rather than adding a method to the presenter, which seems to be the standard way to do it.