### PR TITLE
Cleaner version

### DIFF
--- a/willow/lib/solr/concerns/index_types.rb
+++ b/willow/lib/solr/concerns/index_types.rb
@@ -9,16 +9,14 @@ module Solr
             names.each do |name|
               #use the instance solr_name definition defined in this file unless overridden
               define_method name do |*options|
-                options=options.empty? ? index_type : [index_type] +  options
-                solr_name(name, *options)
+                solr_name(name, index_type, *options)
               end
             end
           end
 
           #Uses the class solr_name definition as defined in Hydra::Controller::ControllerBehaviour and possibly others
           define_singleton_method(index_type.to_s+'_name') do |name, *options|
-            options=options.empty? ? index_type : [index_type] +  options
-            solr_name(name, *options)
+            solr_name(name, index_type, *options)
           end
         end
       end


### PR DESCRIPTION
Removed the redundant code and passed the prefixed index_type directly before the *options to the solr_name instance method.