### PR TITLE
Feature/rdsssam 204 javascript fixes for nested models

### DIFF
--- a/willow/app/assets/javascripts/nested_field_manager.js
+++ b/willow/app/assets/javascripts/nested_field_manager.js
@@ -171,7 +171,10 @@ var NestedFieldManager = function () {
         key: 'createNewField',
         value: function createNewField($activeField, $currentId, $newId) {
             var $newField = $activeField.clone();
-            $newField;
+            // only keep the first of any multiple fields
+            // look for li immediately after li tags which are direct parents of ul.listing
+            // and then remove them
+            $newField.find('ul.listing > li + li').remove();
             this.updateIndexInLabel($newField, $currentId, $newId);
             var $newChildren = $newField.find('.form-control');
             $newChildren.val('').removeProp('required').removeAttr('style');

--- a/willow/app/assets/javascripts/nested_field_manager.js
+++ b/willow/app/assets/javascripts/nested_field_manager.js
@@ -171,8 +171,8 @@ var NestedFieldManager = function () {
             var $newIdPart = 'attributes_' + $newId + '_';
             $newChildren.each(function () {
                 var $currentId = $(this).attr('id');
-                var $newId = $currentId.replaceNthOccurrence($currentIdPart, $newIdPart, nestedLevel);
-                $(this).attr('id', $newId);
+                var $newHtmlId = $currentId.replaceNthOccurrence($currentIdPart, $newIdPart, nestedLevel);
+                $(this).attr('id', $newHtmlId);
             });
             return $newChildren;
         }

--- a/willow/app/assets/javascripts/nested_field_manager.js
+++ b/willow/app/assets/javascripts/nested_field_manager.js
@@ -72,7 +72,8 @@ var NestedFieldManager = function () {
             // inside a multi nested input, allow the hyrax javascript code to run instead.
             if($target.is('.multi_value *')) return; 
             event.preventDefault();
-            var $listing = $(event.target).closest('.multi-nested').find(this.listClass);
+            event.stopPropagation();
+            var $listing = $target.closest('.multi-nested').children(this.listClass);
             var $listElements = $listing.children('li');
             var $activeField = $listElements.last();
             var $newId = $listElements.length;

--- a/willow/app/assets/javascripts/nested_field_manager.js
+++ b/willow/app/assets/javascripts/nested_field_manager.js
@@ -175,11 +175,8 @@ var NestedFieldManager = function () {
         key: 'updateIndexInLabel',
         value: function updateIndexInLabel($newField, currentId, newId, nestedLevel) {
             // Modify name in label
-            //var currentLabelPart = 'attributes_' + $currentId + '_';
-            //var newLabelPart = 'attributes_' + $newId + '_';
             $newField.find('label').each(function () {
                 var currentLabel = $(this).attr('for');
-                //var newLabel = currentLabel.replaceNthOccurrence(currentLabelPart, newLabelPart, nestedLevel);
                 var newLabel = replaceAttributesId(currentLabel, currentId, newId, nestedLevel);
                 $(this).attr('for', newLabel);
             });
@@ -189,11 +186,8 @@ var NestedFieldManager = function () {
         key: 'updateIndexInId',
         value: function updateIndexInId($newChildren, currentId, newId, nestedLevel) {
             // modify id and name in newChildren
-            //var $currentIdPart = 'attributes_' + $currentId + '_';
-            //var $newIdPart = 'attributes_' + $newId + '_';
             $newChildren.each(function () {
                 var currentHtmlId = $(this).attr('id');
-                //var $newHtmlId = $currentId.replaceNthOccurrence($currentIdPart, $newIdPart, nestedLevel);
                 var newHtmlId = replaceAttributesId(currentHtmlId, currentId, newId, nestedLevel);
                 $(this).attr('id', newHtmlId);
             });
@@ -203,11 +197,8 @@ var NestedFieldManager = function () {
         key: 'updateIndexInName',
         value: function updateIndexInName($newChildren, currentId, newId, nestedLevel) {
             // modify id and name in newChildren
-            //var $currentNamePart = '[' + $currentId + ']';
-            //var $newnamePart = '[' + $newId + ']';
             $newChildren.each(function () {
                 var currentName = $(this).attr('name');
-                //var $newName = $currentName.replaceNthOccurrence($currentNamePart, $newnamePart, nestedLevel);
                 var newName = replaceSquareBracketsId(currentName, currentId, newId, nestedLevel)
                 $(this).attr('name', newName);
             });

--- a/willow/app/assets/javascripts/nested_field_manager.js
+++ b/willow/app/assets/javascripts/nested_field_manager.js
@@ -219,7 +219,7 @@ var NestedFieldManager = function () {
         value: function removeFromList(event) {
             event.preventDefault();
             event.stopPropagation();
-            var $activeField = $(event.target).parents(this.fieldWrapperClass);
+            var $activeField = $(event.target).closest(this.fieldWrapperClass); // only apply to nearest parent
             $activeField.find(this.removeInputClass).val('1');
             $activeField.hide();
             this._manageFocus();

--- a/willow/app/assets/javascripts/nested_field_manager.js
+++ b/willow/app/assets/javascripts/nested_field_manager.js
@@ -94,6 +94,10 @@ var NestedFieldManager = function () {
             } else {
                 this.clearEmptyWarning();
                 $listing.append(this._newField($activeField, $currentId, $newId));
+                // instantiate any mutli-nested fields or multi-value fields
+                $listing.find('.multi-nested').manage_nested_fields();
+                $listing.find('.multi_value').manage_fields();
+
             }
             this._manageFocus();
         }

--- a/willow/app/assets/javascripts/nested_field_manager.js
+++ b/willow/app/assets/javascripts/nested_field_manager.js
@@ -4,16 +4,25 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-/** add a replaceLastOccurrence method to String. Replaces the last occurrence of a 'searchValue' with 'newValue' in string **/
+/** add a replaceNthOccurrence method to String. 
+    Replaces the Nth occurrence of a 'searchValue' with 'newValue' in string
+    Where N is 0 indexed.
+    E.G 
+    "hello bob, how are you bob, are you doing well bob".replaceNthOccurrence('bob', 'jane', 1);
+    => "hello bob, how are you jane, are you doing well bob"
+**/
 /** note this cannot take regular expressions **/
-if (!String.prototype.replaceLastOccurrence) {
-    String.prototype.replaceLastOccurrence = function(searchValue, newValue) {
-        var index = this.lastIndexOf(searchValue);
-
-        if (index >= 0) {
-            return this.substring(0, index) + newValue + this.substring(index + searchValue.length);
+if (!String.prototype.replaceNthOccurrence) {
+    String.prototype.replaceNthOccurrence = function(searchValue, newValue, n) {
+        var index = 0;
+        for(var i = 0; i <= n; i++){ // do it n times
+            // get the index of the search value, starting from the character after the previous index
+            index = this.indexOf(searchValue, index+1); 
         }
-
+        if (index >= 0) {
+            var str = this.substring(0, index) + newValue + this.substring(index + searchValue.length);
+            return str;
+        }
         return this.toString();
     };
 }
@@ -29,7 +38,7 @@ var NestedFieldManager = function () {
         this.listClass = options.listClass;
         this.fieldWrapperClass = options.fieldWrapperClass;
         this.removeInputClass = options.removeInputClass;
-
+        this.nestedLevel = this.element.parents('.multi-nested').length;
         this.init();
     }
 
@@ -128,50 +137,50 @@ var NestedFieldManager = function () {
         value: function createNewField($activeField, $currentId, $newId) {
             var $newField = $activeField.clone();
             $newField;
-            this.updateIndexInLabel($newField, $currentId, $newId);
+            this.updateIndexInLabel($newField, $currentId, $newId, this.nestedLevel);
             var $newChildren = $newField.find('.form-control');
             $newChildren.val('').removeProp('required').removeAttr('style');
-            this.updateIndexInId($newChildren, $currentId, $newId);
-            this.updateIndexInName($newChildren, $currentId, $newId);
+            this.updateIndexInId($newChildren, $currentId, $newId, this.nestedLevel);
+            this.updateIndexInName($newChildren, $currentId, $newId, this.nestedLevel);
             $newChildren.first().focus();
             this.element.trigger("manage_nested_fields:add", $newChildren.first());
             return $newField;
         }
     }, {
         key: 'updateIndexInLabel',
-        value: function updateIndexInLabel($newField, $currentId, $newId) {
+        value: function updateIndexInLabel($newField, $currentId, $newId, nestedLevel) {
             // Modify name in label
             var currentLabelPart = 'attributes_' + $currentId + '_';
             var newLabelPart = 'attributes_' + $newId + '_';
             $newField.find('label').each(function () {
                 var currentLabel = $(this).attr('for');
-                var newLabel = currentLabel.replaceLastOccurrence(currentLabelPart, newLabelPart);
+                var newLabel = currentLabel.replaceNthOccurrence(currentLabelPart, newLabelPart, nestedLevel);
                 $(this).attr('for', newLabel);
             });
             return $newField;
         }
     }, {
         key: 'updateIndexInId',
-        value: function updateIndexInId($newChildren, $currentId, $newId) {
+        value: function updateIndexInId($newChildren, $currentId, $newId, nestedLevel) {
             // modify id and name in newChildren
             var $currentIdPart = 'attributes_' + $currentId + '_';
             var $newIdPart = 'attributes_' + $newId + '_';
             $newChildren.each(function () {
                 var $currentId = $(this).attr('id');
-                var $newId = $currentId.replaceLastOccurrence($currentIdPart, $newIdPart);
+                var $newId = $currentId.replaceNthOccurrence($currentIdPart, $newIdPart, nestedLevel);
                 $(this).attr('id', $newId);
             });
             return $newChildren;
         }
     }, {
         key: 'updateIndexInName',
-        value: function updateIndexInName($newChildren, $currentId, $newId) {
+        value: function updateIndexInName($newChildren, $currentId, $newId, nestedLevel) {
             // modify id and name in newChildren
             var $currentNamePart = '[' + $currentId + ']';
             var $newnamePart = '[' + $newId + ']';
             $newChildren.each(function () {
                 var $currentName = $(this).attr('name');
-                var $newName = $currentName.replaceLastOccurrence($currentNamePart, $newnamePart);
+                var $newName = $currentName.replaceNthOccurrence($currentNamePart, $newnamePart, nestedLevel);
                 $(this).attr('name', $newName);
             });
             return $newChildren;

--- a/willow/app/assets/javascripts/nested_field_manager.js
+++ b/willow/app/assets/javascripts/nested_field_manager.js
@@ -67,6 +67,10 @@ var NestedFieldManager = function () {
     }, {
         key: 'addToList',
         value: function addToList(event) {
+            var $target = $(event.target);
+            // If the 'add another' button has been clicked for a standard multivalue input
+            // inside a multi nested input, allow the hyrax javascript code to run instead.
+            if($target.is('.multi_value *')) return; 
             event.preventDefault();
             var $listing = $(event.target).closest('.multi-nested').find(this.listClass);
             var $listElements = $listing.children('li');

--- a/willow/app/assets/javascripts/nested_field_manager.js
+++ b/willow/app/assets/javascripts/nested_field_manager.js
@@ -172,19 +172,20 @@ var NestedFieldManager = function () {
         value: function createNewField($activeField, $currentId, $newId) {
             var $newField = $activeField.clone();
             $newField;
-            this.updateIndexInLabel($newField, $currentId, $newId, this.nestedLevel);
+            this.updateIndexInLabel($newField, $currentId, $newId);
             var $newChildren = $newField.find('.form-control');
             $newChildren.val('').removeProp('required').removeAttr('style');
-            this.updateIndexInId($newChildren, $currentId, $newId, this.nestedLevel);
-            this.updateIndexInName($newChildren, $currentId, $newId, this.nestedLevel);
+            this.updateIndexInId($newChildren, $currentId, $newId);
+            this.updateIndexInName($newChildren, $currentId, $newId);
             $newChildren.first().focus();
             this.element.trigger("manage_nested_fields:add", $newChildren.first());
             return $newField;
         }
     }, {
         key: 'updateIndexInLabel',
-        value: function updateIndexInLabel($newField, currentId, newId, nestedLevel) {
+        value: function updateIndexInLabel($newField, currentId, newId) {
             // Modify name in label
+            var nestedLevel = this.nestedLevel;
             $newField.find('label').each(function () {
                 var currentLabel = $(this).attr('for');
                 var newLabel = replaceAttributesId(currentLabel, currentId, newId, nestedLevel);
@@ -194,8 +195,9 @@ var NestedFieldManager = function () {
         }
     }, {
         key: 'updateIndexInId',
-        value: function updateIndexInId($newChildren, currentId, newId, nestedLevel) {
+        value: function updateIndexInId($newChildren, currentId, newId) {
             // modify id and name in newChildren
+            var nestedLevel = this.nestedLevel;
             $newChildren.each(function () {
                 var currentHtmlId = $(this).attr('id');
                 var newHtmlId = replaceAttributesId(currentHtmlId, currentId, newId, nestedLevel);
@@ -205,8 +207,9 @@ var NestedFieldManager = function () {
         }
     }, {
         key: 'updateIndexInName',
-        value: function updateIndexInName($newChildren, currentId, newId, nestedLevel) {
+        value: function updateIndexInName($newChildren, currentId, newId) {
             // modify id and name in newChildren
+            var nestedLevel = this.nestedLevel;
             $newChildren.each(function () {
                 var currentName = $(this).attr('name');
                 var newName = replaceSquareBracketsId(currentName, currentId, newId, nestedLevel)

--- a/willow/app/assets/javascripts/nested_field_manager.js
+++ b/willow/app/assets/javascripts/nested_field_manager.js
@@ -218,6 +218,7 @@ var NestedFieldManager = function () {
         key: 'removeFromList',
         value: function removeFromList(event) {
             event.preventDefault();
+            event.stopPropagation();
             var $activeField = $(event.target).parents(this.fieldWrapperClass);
             $activeField.find(this.removeInputClass).val('1');
             $activeField.hide();

--- a/willow/app/assets/javascripts/nested_field_manager.js
+++ b/willow/app/assets/javascripts/nested_field_manager.js
@@ -5,8 +5,8 @@ var _createClass = function () { function defineProperties(target, props) { for 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
   /**
-    For an input string, find the nth occurence of a regex, and then replace the old id within that occurrence
-    with the new id.
+    For an input string, find the Nth occurence of a regex (which defines a surrounding context for an ID), 
+    and then replace the old id within that occurrence with a new id.
     Parameters:
     string: the original string to be manipulated
     contextRegex: A regular expression that expresses the context surrounding the id.
@@ -24,14 +24,24 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
     Expected result => "bob[0]james[1]fred[2]"
   **/
 function replaceIdInContext(string, contextRegex, originalId, newId, nOccurrence){
+    // variable to keep the current match within the regex
     var match = null;
+    // the resultin string to return. Default to the original string
     var result = string;
+    // find the Nth match in the string
+    // to do that we call exec on the regex N times
     for(var i = 0; i <= nOccurrence; i++){
-        match = contextRegex.exec(string); // find the nth match in the string
+        match = contextRegex.exec(string); 
     }
-    if(match && match[1] && match[1] == originalId){ // if we have a match, and their is a captured group, and that equals the id
-        var newString = match[0].replace(originalId, newId) // I.E [0] => [1]
-        // Replace the new id and it's context into the original string
+    // if we have a match, and there is a captured group, and that equals the id
+    // go ahead with the replacement
+    if(match && match[1] && match[1] == originalId){ 
+        // replace the old id with the new in the matching string
+        // E.G [0] => [1]
+        var newString = match[0].replace(originalId, newId) 
+        
+        // insert the new id and it's context (newString) into the original string
+        // at the index indicated by the match
         result = string.substring(0, match.index) + newString + string.substring(match.index + newString.length); 
     }
     return result;


### PR DESCRIPTION
Javascript fixes to the cottagelabs javascript for nested models. Specifically fixes:

- replacing indexes in the correct "[]" of an attribute name. for example "object_rights[0][acesses][0]" should change to "object_rights[0][acesses][1]" when you add another 'access' and "object_rights[1][acesses][0]"  when you add another "object_rights"

- Adding the new nested form in the correct place when pressing "add another" for a nested model.

- Making sure that when adding a new nested model in the form, the new dom elements have add and remove buttons that work

- Preventing the cottage labs 'add another' code from running if you click a standard multi value field inside a nested model.
