### PR TITLE
Feature/rdsssam 171 object and related identifiers

### DIFF
--- a/willow/app/forms/hyrax/rdss_cdm_form.rb
+++ b/willow/app/forms/hyrax/rdss_cdm_form.rb
@@ -156,17 +156,15 @@ module Hyrax
     end
 
     def self.permitted_object_related_identifier_params
-      [:id,
-       :_destroy,
-       [
-         :relation_type,
-         identifier_attributes: [
+      [
+        :id,
+        :_destroy,
+        :relation_type,
+        identifier_attributes: [
           :id,
-           [
-             :identifier_value,
-             :identifier_type
-            ]
-          ]
+          :_destroy,
+          :identifier_value,
+          :identifier_type
         ]
       ]
     end
@@ -179,6 +177,7 @@ module Hyrax
       permitted << { object_rights_attributes: permitted_object_rights_params }
       permitted << { object_organisation_roles_attributes: permitted_object_organisation_roles_params }
       permitted << { object_identifiers_attributes: permitted_object_identifier_params }
+      permitted << { object_related_identifiers_attributes: permitted_object_related_identifier_params }
       permitted
     end
   end

--- a/willow/app/forms/hyrax/rdss_cdm_form.rb
+++ b/willow/app/forms/hyrax/rdss_cdm_form.rb
@@ -17,6 +17,7 @@ module Hyrax
       :object_dates,
       :object_rights,
       :object_organisation_roles,
+      :object_identifiers,
     ]
 
     self.required_fields = [
@@ -26,11 +27,13 @@ module Hyrax
       :object_people,
       :object_rights,
       :object_organisation_roles,
+      :object_identifiers,
     ]
 
     mapped_arrays :object_dates,
                   :object_person_roles,
-                  :object_organisation_roles
+                  :object_organisation_roles,
+                  :object_identifiers
 
     def object_people
       convert_value_to_array(model.object_people)
@@ -48,6 +51,7 @@ module Hyrax
              :object_people_attributes=,
              :object_rights_attributes=,
              :object_organisation_roles_attributes=,
+             :object_identifiers_attributes=,
              to: :model
 
     # for object_rights, we present the has_many relationship as a has_one
@@ -127,11 +131,23 @@ module Hyrax
       ]
     end
 
+
     def self.permitted_object_organisation_roles_params
       [
         :id,
         :role,
         :_destroy
+      ]
+    end
+
+
+    def self.permitted_object_identifier_params
+      [:id,
+       :_destroy,
+       [
+         :identifier_value,
+         :identifier_type
+        ]
       ]
     end
 
@@ -142,6 +158,7 @@ module Hyrax
       permitted << { object_people_attributes: permitted_object_person_nested }
       permitted << { object_rights_attributes: permitted_object_rights_params }
       permitted << { object_organisation_roles_attributes: permitted_object_organisation_roles_params }
+      permitted << { object_identifiers_attributes: permitted_object_identifier_params }
       permitted
     end
   end

--- a/willow/app/forms/hyrax/rdss_cdm_form.rb
+++ b/willow/app/forms/hyrax/rdss_cdm_form.rb
@@ -18,6 +18,7 @@ module Hyrax
       :object_rights,
       :object_organisation_roles,
       :object_identifiers,
+      :object_related_identifiers,
     ]
 
     self.required_fields = [
@@ -33,7 +34,9 @@ module Hyrax
     mapped_arrays :object_dates,
                   :object_person_roles,
                   :object_organisation_roles,
-                  :object_identifiers
+                  :object_identifiers,
+                  :object_related_identifiers
+
 
     def object_people
       convert_value_to_array(model.object_people)
@@ -52,6 +55,7 @@ module Hyrax
              :object_rights_attributes=,
              :object_organisation_roles_attributes=,
              :object_identifiers_attributes=,
+             :object_related_identifiers_attributes=,             
              to: :model
 
     # for object_rights, we present the has_many relationship as a has_one
@@ -147,6 +151,22 @@ module Hyrax
        [
          :identifier_value,
          :identifier_type
+        ]
+      ]
+    end
+
+    def self.permitted_object_related_identifier_params
+      [:id,
+       :_destroy,
+       [
+         :relation_type,
+         identifier_attributes: [
+          :id,
+           [
+             :identifier_value,
+             :identifier_type
+            ]
+          ]
         ]
       ]
     end

--- a/willow/app/forms/hyrax/rdss_cdm_form.rb
+++ b/willow/app/forms/hyrax/rdss_cdm_form.rb
@@ -146,12 +146,11 @@ module Hyrax
 
 
     def self.permitted_object_identifier_params
-      [:id,
-       :_destroy,
-       [
-         :identifier_value,
-         :identifier_type
-        ]
+      [
+        :id,
+        :_destroy,
+        :identifier_value,
+        :identifier_type
       ]
     end
 
@@ -160,12 +159,7 @@ module Hyrax
         :id,
         :_destroy,
         :relation_type,
-        identifier_attributes: [
-          :id,
-          :_destroy,
-          :identifier_value,
-          :identifier_type
-        ]
+        identifier_attributes: permitted_object_identifier_params
       ]
     end
 

--- a/willow/app/forms/hyrax/rdss_cdm_form.rb
+++ b/willow/app/forms/hyrax/rdss_cdm_form.rb
@@ -32,7 +32,6 @@ module Hyrax
     ]
 
     mapped_arrays :object_dates,
-                  :object_person_roles,
                   :object_organisation_roles,
                   :object_identifiers,
                   :object_related_identifiers

--- a/willow/app/indexers/rdss_cdm_indexer.rb
+++ b/willow/app/indexers/rdss_cdm_indexer.rb
@@ -56,6 +56,10 @@ class RdssCdmIndexer < Hyrax::WorkIndexer
       object_identifiers.each do |i|
         solr_doc[Solrizer.solr_name("object_identifier_#{i.identifier_type}", :stored_sortable)] = i.identifier_value
       end
+
+      # Index a displayable version of the related identifier
+      object_related_identifiers = object.object_related_identifiers.reject(&:marked_for_destruction?)
+      solr_doc[Solrizer.solr_name('object_related_identifiers', :displayable)] = object_related_identifiers.to_json(include: :identifier)
     end
   end
 end

--- a/willow/app/indexers/rdss_cdm_indexer.rb
+++ b/willow/app/indexers/rdss_cdm_indexer.rb
@@ -48,6 +48,14 @@ class RdssCdmIndexer < Hyrax::WorkIndexer
       object_organisation_roles.each do |object_organisation_role|
         solr_doc[::Solrizer.solr_name("object_organisation_role_#{object_organisation_role.role}", :stored_sortable)] = true
       end
+
+      # Index a displayable version of the identifier
+      object_identifiers = object.object_identifiers.reject(&:marked_for_destruction?)
+      solr_doc[Solrizer.solr_name('object_identifiers', :displayable)] = object_identifiers.to_json
+      # Incase we need it, solarize each identifier type
+      object_identifiers.each do |i|
+        solr_doc[Solrizer.solr_name("object_identifier_#{i.identifier_type}", :stored_sortable)] = i.identifier_value
+      end
     end
   end
 end

--- a/willow/app/inputs/object_identifier_form_builder.rb
+++ b/willow/app/inputs/object_identifier_form_builder.rb
@@ -1,0 +1,9 @@
+class ObjectIdentifierFormBuilder < RdssFields
+  def identifier_type(required: false)
+    input :identifier_type, collection: Cdm::IdentifierTypesService.select_all_options, prompt: :translate, label: false, required: required
+  end
+
+  def identifier_value(required: false)
+    input :identifier_value, label: false, required: required
+  end
+end

--- a/willow/app/inputs/object_related_identifier_form_builder.rb
+++ b/willow/app/inputs/object_related_identifier_form_builder.rb
@@ -1,0 +1,9 @@
+class ObjectRelatedIdentifierFormBuilder < RdssFields
+  def relation_type(required: false)
+    input :relation_type, collection: Cdm::RelationTypesService.select_all_options, prompt: :translate, label: false, required: required
+  end
+
+  def identifier
+    object.build_identifier if object.identifier.blank?
+  end
+end

--- a/willow/app/models/cdm/identifier.rb
+++ b/willow/app/models/cdm/identifier.rb
@@ -1,0 +1,9 @@
+module Cdm
+  # Active fedora model representing an object date for an rdss_cdm model
+  class Identifier < ActiveFedora::Base
+    include Cdm::Concerns::ModelExtensions
+    #property :date_value, predicate: ::RDF::Vocab::DC.date, multiple: false
+    property :identifier_value, predicate: ::RDF::Vocab::DataCite.hasIdentifier, multiple: false
+    property :identifier_type, predicate: ::RDF::Vocab::DataCite.usesIdentifierScheme, multiple: false
+  end
+end

--- a/willow/app/models/cdm/identifier.rb
+++ b/willow/app/models/cdm/identifier.rb
@@ -5,5 +5,7 @@ module Cdm
     #property :date_value, predicate: ::RDF::Vocab::DC.date, multiple: false
     property :identifier_value, predicate: ::RDF::Vocab::DataCite.hasIdentifier, multiple: false
     property :identifier_type, predicate: ::RDF::Vocab::DataCite.usesIdentifierScheme, multiple: false
+
+    has_many :identifier_relationships, class_name: 'Cdm::IdentifierRelationship'
   end
 end

--- a/willow/app/models/cdm/identifier_relationship.rb
+++ b/willow/app/models/cdm/identifier_relationship.rb
@@ -4,5 +4,7 @@ module Cdm
     include Cdm::Concerns::ModelExtensions
     property :relation_type, predicate: ::RDF::Vocab::MODS.roleRelationshipRole, multiple: false
     belongs_to :identifier, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isMetadataFor, class_name: 'Cdm::Identifier'
+
+    accepts_nested_attributes_for :identifier
   end
 end

--- a/willow/app/models/cdm/identifier_relationship.rb
+++ b/willow/app/models/cdm/identifier_relationship.rb
@@ -6,5 +6,15 @@ module Cdm
     belongs_to :identifier, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isMetadataFor, class_name: 'Cdm::Identifier'
 
     accepts_nested_attributes_for :identifier
+
+    # Override identifier_attributes
+    # There is a wierd bug in active fedora where for a belongs_to association, a new record will lose it's attributes
+    # We get around this by after an assignment, if the identifier is a new record, reassign the attributes before a save
+    def identifier_attributes= atts
+      super atts
+      if identifier && identifier.new_record?
+        identifier.attributes= atts
+      end
+    end
   end
 end

--- a/willow/app/models/cdm/identifier_relationship.rb
+++ b/willow/app/models/cdm/identifier_relationship.rb
@@ -1,0 +1,8 @@
+module Cdm
+  # Active fedora model representing an object date for an rdss_cdm model
+  class IdentifierRelationship < ActiveFedora::Base
+    include Cdm::Concerns::ModelExtensions
+    property :relation_type, predicate: ::RDF::Vocab::MODS.roleRelationshipRole, multiple: false
+    belongs_to :identifier, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isMetadataFor, class_name: 'Cdm::Identifier'
+  end
+end

--- a/willow/app/models/cdm/json/identifier.rb
+++ b/willow/app/models/cdm/json/identifier.rb
@@ -1,0 +1,12 @@
+module Cdm
+  module Json
+    class Identifier < ::Cdm::Json::ModelBase
+      attr_reader :type, :value
+      def initialize(values={})
+        @type=values['identifier_type']
+        @value=values['identifier_value']
+        super
+      end
+    end
+  end
+end

--- a/willow/app/models/cdm/json/related_identifier.rb
+++ b/willow/app/models/cdm/json/related_identifier.rb
@@ -4,7 +4,8 @@ module Cdm
       attr_reader :relation_type, :identifier_type, :identifier_value
       def initialize(values={})
         @relation_type = values['relation_type']
-        if(identifier = values['identifier'])
+        identifier = values['identifier']
+        if(identifier)
           @identifier_type = identifier['identifier_type']
           @identifier_value = identifier['identifier_value']
         end

--- a/willow/app/models/cdm/json/related_identifier.rb
+++ b/willow/app/models/cdm/json/related_identifier.rb
@@ -1,0 +1,15 @@
+module Cdm
+  module Json
+    class RelatedIdentifier < ::Cdm::Json::ModelBase
+      attr_reader :relation_type, :identifier_type, :identifier_value
+      def initialize(values={})
+        @relation_type = values['relation_type']
+        if(identifier = values['identifier'])
+          @identifier_type = identifier['identifier_type']
+          @identifier_value = identifier['identifier_value']
+        end
+        super
+      end
+    end
+  end
+end

--- a/willow/app/models/concerns/rdss_cdm_extensions.rb
+++ b/willow/app/models/concerns/rdss_cdm_extensions.rb
@@ -17,6 +17,7 @@ module Concerns
                 :object_organisation_roles,
                 :object_people,
                 :object_rights_accesses,
-                :object_identifiers
+                :object_identifiers,
+                :object_related_identifiers
   end
 end

--- a/willow/app/models/concerns/rdss_cdm_extensions.rb
+++ b/willow/app/models/concerns/rdss_cdm_extensions.rb
@@ -16,6 +16,7 @@ module Concerns
                 :object_rights_accesses,
                 :object_organisation_roles,
                 :object_people,
-                :object_rights_accesses
+                :object_rights_accesses,
+                :object_identifiers
   end
 end

--- a/willow/app/models/rdss_cdm.rb
+++ b/willow/app/models/rdss_cdm.rb
@@ -49,6 +49,8 @@ class RdssCdm < ActiveFedora::Base
     index.as :stored_searchable
   end
   #property :object_identifier
+  has_many :object_identifiers, class_name: 'Cdm::Identifier'
+
   #property :object_related_identifier
   #property :object_organisation_role
   #property :object_preservation_event

--- a/willow/app/models/rdss_cdm.rb
+++ b/willow/app/models/rdss_cdm.rb
@@ -129,11 +129,11 @@ class RdssCdm < ActiveFedora::Base
   end
 
   def object_identifiers_blank?(attributes)
-    object_values_blank?(attributes, :identifier_type, :identifier_value)
+    any_blank?(attributes, :identifier_type, :identifier_value)
   end
 
   def object_related_identifiers_blank?(attributes)
-    object_values_blank?(attributes, :relation_type)
+    any_blank?(attributes, :relation_type)
   end
 
   def object_person_roles_blank?(attributes)

--- a/willow/app/models/rdss_cdm.rb
+++ b/willow/app/models/rdss_cdm.rb
@@ -70,6 +70,7 @@ class RdssCdm < ActiveFedora::Base
   accepts_nested_attributes_for :object_organisation_roles, allow_destroy: true, reject_if: :object_organisation_roles_blank?
   accepts_nested_attributes_for :object_people, allow_destroy: true, reject_if: :object_person_blank?
   accepts_nested_attributes_for :object_rights
+  accepts_nested_attributes_for :object_identifiers, allow_destroy: true, reject_if: :object_identifiers_blank?
 
   def self.multiple?(field)
     # Overriding to return false for `title` (as we can't set multiple: false) 
@@ -122,6 +123,10 @@ class RdssCdm < ActiveFedora::Base
 
   def object_dates_blank?(attributes)
     any_blank?(attributes, :date_value, :date_type)
+  end
+
+  def object_identifiers_blank?(attributes)
+    object_values_blank?(attributes, :identifier_type, :identifier_value)
   end
 
   def object_person_roles_blank?(attributes)

--- a/willow/app/models/rdss_cdm.rb
+++ b/willow/app/models/rdss_cdm.rb
@@ -52,6 +52,8 @@ class RdssCdm < ActiveFedora::Base
   has_many :object_identifiers, class_name: 'Cdm::Identifier'
 
   #property :object_related_identifier
+  has_many :object_related_identifiers, class_name: 'Cdm::IdentifierRelationship'
+  
   #property :object_organisation_role
   #property :object_preservation_event
   #property :object_file

--- a/willow/app/models/rdss_cdm.rb
+++ b/willow/app/models/rdss_cdm.rb
@@ -73,6 +73,7 @@ class RdssCdm < ActiveFedora::Base
   accepts_nested_attributes_for :object_people, allow_destroy: true, reject_if: :object_person_blank?
   accepts_nested_attributes_for :object_rights
   accepts_nested_attributes_for :object_identifiers, allow_destroy: true, reject_if: :object_identifiers_blank?
+  accepts_nested_attributes_for :object_related_identifiers, allow_destroy: true, reject_if: :object_related_identifiers_blank?
 
   def self.multiple?(field)
     # Overriding to return false for `title` (as we can't set multiple: false) 
@@ -129,6 +130,10 @@ class RdssCdm < ActiveFedora::Base
 
   def object_identifiers_blank?(attributes)
     object_values_blank?(attributes, :identifier_type, :identifier_value)
+  end
+
+  def object_related_identifiers_blank?(attributes)
+    object_values_blank?(attributes, :relation_type)
   end
 
   def object_person_roles_blank?(attributes)

--- a/willow/app/presenters/hyrax/rdss_cdm_presenter.rb
+++ b/willow/app/presenters/hyrax/rdss_cdm_presenter.rb
@@ -17,6 +17,7 @@ module Hyrax
              :object_rights_accesses,
              :object_organisation_roles,
              :object_identifiers,
+             :object_related_identifiers,
              to: :solr_document
   end
 end

--- a/willow/app/presenters/hyrax/rdss_cdm_presenter.rb
+++ b/willow/app/presenters/hyrax/rdss_cdm_presenter.rb
@@ -16,6 +16,7 @@ module Hyrax
              :object_rights_rights_holder,
              :object_rights_accesses,
              :object_organisation_roles,
+             :object_identifiers,
              to: :solr_document
   end
 end

--- a/willow/app/renderers/object_identifiers_attribute_renderer.rb
+++ b/willow/app/renderers/object_identifiers_attribute_renderer.rb
@@ -1,0 +1,25 @@
+class ObjectIdentifiersAttributeRenderer < Hyrax::Renderers::AttributeRenderer
+  private
+  include Concerns::CssTableRenderer
+
+  def identifiers(value)
+    json = [JSON.parse(value)].flatten # make sure we get an array, even if the json is just a single value
+    json.map{|x| ::Cdm::Json::Identifier.new(x) unless x.empty?}.compact # reject any rows that are empty
+  end
+
+  def attribute_value_to_html(value)
+    table {
+      thead {
+        row { header { "Type" } + header { "Value" } }
+      } + 
+      tbody {
+        identifiers(value).map do |identifier|
+          row {
+            cell { I18n.t("rdss.identifier_types.#{identifier.type}", default: identifier.type)} + 
+            cell { identifier.value }
+          }
+        end.join
+      }
+    }
+  end
+end

--- a/willow/app/renderers/object_related_identifiers_attribute_renderer.rb
+++ b/willow/app/renderers/object_related_identifiers_attribute_renderer.rb
@@ -1,0 +1,27 @@
+class ObjectRelatedIdentifiersAttributeRenderer < Hyrax::Renderers::AttributeRenderer
+  private
+  include Concerns::CssTableRenderer
+
+  def related_identifiers(value)
+    json = JSON.parse(value)
+    json = [json] unless json.is_a? Array  # make sure we get an array, even if the json is just a single value
+    json.map{|x| ::Cdm::Json::RelatedIdentifier.new(x) unless x.empty?}.compact # reject any rows that are empty
+  end
+
+  def attribute_value_to_html(value)
+    table {
+      thead {
+        row { header { "Relation" } + header { "Type" } + header { "Value" } }
+      } + 
+      tbody {
+        related_identifiers(value).map do |ri|
+          row {
+            cell { I18n.t("rdss.relation_types.#{ri.relation_type}", default: ri.relation_type) if ri.relation_type} + 
+            cell { I18n.t("rdss.identifier_types.#{ri.identifier_type}", default: ri.identifier_type) if ri.identifier_type} + 
+            cell { ri.identifier_value }
+          }
+        end.join
+      }
+    }
+  end
+end

--- a/willow/app/services/cdm/identifier_types_service.rb
+++ b/willow/app/services/cdm/identifier_types_service.rb
@@ -1,0 +1,13 @@
+module Cdm
+  class IdentifierTypesService < ServicesBase
+    class << self
+      def authority_name
+        'rdss_identifier_types'
+      end
+
+      def internationalisation_root
+        'rdss.identifier_types.'
+      end
+    end
+  end
+end

--- a/willow/app/services/cdm/relation_types_service.rb
+++ b/willow/app/services/cdm/relation_types_service.rb
@@ -1,0 +1,13 @@
+module Cdm
+  class RelationTypesService < ServicesBase
+    class << self
+      def authority_name
+        'rdss_relation_types'
+      end
+
+      def internationalisation_root
+        'rdss.relation_types.'
+      end
+    end
+  end
+end

--- a/willow/app/views/hyrax/rdss_cdms/_attribute_rows.html.erb
+++ b/willow/app/views/hyrax/rdss_cdms/_attribute_rows.html.erb
@@ -12,3 +12,6 @@
 <%= presenter.attribute_to_html(:object_rights_rights_statement) %>
 <%= presenter.attribute_to_html(:object_rights_rights_holder) %>
 <%= presenter.attribute_to_html(:object_rights_accesses, render_as: :object_rights_accesses) %>
+<%# identifiers %>
+<%= presenter.attribute_to_html(:object_identifiers, render_as: :object_identifiers) %>
+

--- a/willow/app/views/hyrax/rdss_cdms/_attribute_rows.html.erb
+++ b/willow/app/views/hyrax/rdss_cdms/_attribute_rows.html.erb
@@ -14,4 +14,5 @@
 <%= presenter.attribute_to_html(:object_rights_accesses, render_as: :object_rights_accesses) %>
 <%# identifiers %>
 <%= presenter.attribute_to_html(:object_identifiers, render_as: :object_identifiers) %>
+<%= presenter.attribute_to_html(:object_related_identifiers, render_as: :object_related_identifiers) %>
 

--- a/willow/app/views/hyrax/rdss_cdms/_object_identifier_form.html.erb
+++ b/willow/app/views/hyrax/rdss_cdms/_object_identifier_form.html.erb
@@ -1,0 +1,14 @@
+<li class="field-wrapper">
+  <div class="row">
+    <div class="col-md-3">
+      <%= object_identifier_form.identifier_type(required: required) %>
+    </div>
+    <div class="col-md-6">
+      <%= object_identifier_form.identifier_value(required: required) %>
+    </div>
+    <div class='col-md-3'>
+      <%= object_identifier_form.destroy %>
+      <%= remove_button :identifier %>
+    </div>
+  </div>
+</li>

--- a/willow/app/views/hyrax/rdss_cdms/_object_related_identifier_form.html.erb
+++ b/willow/app/views/hyrax/rdss_cdms/_object_related_identifier_form.html.erb
@@ -1,0 +1,19 @@
+<li class="field-wrapper">
+  <div class="row">
+    <div class="col-md-2">
+      <%= object_related_identifier_form.relation_type(required: required) %>
+    </div>
+    <%= object_related_identifier_form.fields_for :identifier, object_related_identifier_form.identifier, builder: ::ObjectIdentifierFormBuilder do |identifier| %>
+      <div class="col-md-2">
+        <%= identifier.identifier_type(required: required) %>
+      </div>
+      <div class="col-md-5">
+        <%= identifier.identifier_value(required: required) %>
+      </div>
+    <% end %>
+    <div class='col-md-3'>
+      <%= object_related_identifier_form.destroy %>
+      <%= remove_button :object_related_identifier %>
+    </div>
+  </div>
+</li>

--- a/willow/app/views/records/edit_fields/_object_identifiers.html.erb
+++ b/willow/app/views/records/edit_fields/_object_identifiers.html.erb
@@ -1,0 +1,10 @@
+<div class="multi-nested">
+  <%# only output the label and the hint text. wrapper defined in config/initializers/simple_form_rdss.rb %>
+  <%= f.input :object_identifiers, wrapper: :label_and_hint_only %>
+  <ul class="listing"><%# normally added by https://github.com/samvera/hydra-editor/blob/master/app/inputs/multi_value_input.rb %>
+    <%= f.fields_for :object_identifiers, @form.object_identifiers, builder: ::ObjectIdentifierFormBuilder do |oi| %>
+      <%= render partial: oi, locals: { required: f.object.required?(:object_identifiers) } %>
+    <% end %>
+  </ul>
+  <%= add_another_button :object_identifier %>
+</div>

--- a/willow/app/views/records/edit_fields/_object_related_identifiers.html.erb
+++ b/willow/app/views/records/edit_fields/_object_related_identifiers.html.erb
@@ -1,0 +1,10 @@
+<div class="multi-nested">
+  <%# only output the label and the hint text. wrapper defined in config/initializers/simple_form_rdss.rb %>
+  <%= f.input :object_related_identifiers, wrapper: :label_and_hint_only %>
+  <ul class="listing"><%# normally added by https://github.com/samvera/hydra-editor/blob/master/app/inputs/multi_value_input.rb %>
+    <%= f.fields_for :object_related_identifiers, @form.object_related_identifiers, builder: ::ObjectRelatedIdentifierFormBuilder do |ori| %>
+      <%= render partial: ori, locals: { required: f.object.required?(:object_related_identifiers) } %>
+    <% end %>
+  </ul>
+  <%= add_another_button :object_related_identifier %>
+</div>

--- a/willow/config/locales/en.yml
+++ b/willow/config/locales/en.yml
@@ -72,3 +72,4 @@ en:
       object_rights_license: License
       object_organisation_role: Organisation Role
       given_and_family_name_presence: a minimum of given or family name
+      object_identifier: Identifier

--- a/willow/config/locales/en.yml
+++ b/willow/config/locales/en.yml
@@ -73,3 +73,4 @@ en:
       object_organisation_role: Organisation Role
       given_and_family_name_presence: a minimum of given or family name
       object_identifier: Identifier
+      object_related_identifier: Related identifier

--- a/willow/config/locales/hyrax.en.yml
+++ b/willow/config/locales/hyrax.en.yml
@@ -51,6 +51,8 @@ en:
           rights_tesim: Rights
           subject_tesim: Subject
           title_tesim: Title
+          object_identifiers: Identifiers
+          object_related_identifiers: Related identifiers
   hyrax:
     contact_form:
       header: "Contact Us"

--- a/willow/config/locales/rdss_cdm.en.yml
+++ b/willow/config/locales/rdss_cdm.en.yml
@@ -23,6 +23,7 @@ en:
         orcid: Orcid
         object_rights: Rights
         object_identifiers: Idenitifiers
+        object_related_identifiers: Related idenitifiers
       # note we have to put the following translations under simple_form.labels.defaults
       # rather than simple_form.labels.rdss_cdm.object_rights, as otherwise the translation
       # for simple_form.labels.rdss_cdm.object_rights
@@ -37,6 +38,7 @@ en:
         object_rights: Rights and access information about the dataset
         object_organisation_role: Role the organisation played in the dataset
         object_identifiers: Identifiers for the dataset
+        object_related_identifiers: Identifier for specific content (audio, video, PDF document) related to the dataset. An example is the URL of an article based on this dataset. If adding a related work identifier please also choose the type of relationship.
       defaults:
         # note we have to put the following translations under simple_form.hints.defaults
         # rather than simple_form.hints.rdss_cdm.object_rights, as otherwise the translation
@@ -55,3 +57,5 @@ en:
           license: Select license
         object_identifiers:
           identifier_type: Select type
+        object_related_identifiers:
+          relation_type: Select relation type

--- a/willow/config/locales/rdss_cdm.en.yml
+++ b/willow/config/locales/rdss_cdm.en.yml
@@ -22,6 +22,7 @@ en:
         name: Name
         orcid: Orcid
         object_rights: Rights
+        object_identifiers: Idenitifiers
       # note we have to put the following translations under simple_form.labels.defaults
       # rather than simple_form.labels.rdss_cdm.object_rights, as otherwise the translation
       # for simple_form.labels.rdss_cdm.object_rights
@@ -35,6 +36,7 @@ en:
         object_dates: The different dates relevant to the dataset
         object_rights: Rights and access information about the dataset
         object_organisation_role: Role the organisation played in the dataset
+        object_identifiers: Identifiers for the dataset
       defaults:
         # note we have to put the following translations under simple_form.hints.defaults
         # rather than simple_form.hints.rdss_cdm.object_rights, as otherwise the translation
@@ -51,3 +53,5 @@ en:
           role_type: Choose role
         object_rights:
           license: Select license
+        object_identifiers:
+          identifier_type: Select type

--- a/willow/config/locales/rdss_cdm.en.yml
+++ b/willow/config/locales/rdss_cdm.en.yml
@@ -22,8 +22,8 @@ en:
         name: Name
         orcid: Orcid
         object_rights: Rights
-        object_identifiers: Idenitifiers
-        object_related_identifiers: Related idenitifiers
+        object_identifiers: Identifiers
+        object_related_identifiers: Related identifiers
       # note we have to put the following translations under simple_form.labels.defaults
       # rather than simple_form.labels.rdss_cdm.object_rights, as otherwise the translation
       # for simple_form.labels.rdss_cdm.object_rights

--- a/willow/config/locales/rdss_identifier_types.en.yml
+++ b/willow/config/locales/rdss_identifier_types.en.yml
@@ -1,0 +1,21 @@
+en:
+  rdss:
+    identifier_types:
+      doi: DOI
+      ark: ARK
+      ar_xiv: arXiv
+      bibcode: bibcode
+      ean13: EAN13
+      eissn: EISSN
+      handle: Handle
+      isbn: ISBN
+      issn: ISSN
+      istc: ISTC
+      lissn: LISSN
+      lsid: LSID
+      pmid: PMID
+      puid: PUID
+      purl: PURL
+      upc: UPC
+      url: URL
+      urn: URN

--- a/willow/config/locales/rdss_relation_types.en.yml
+++ b/willow/config/locales/rdss_relation_types.en.yml
@@ -1,0 +1,40 @@
+en:
+  rdss:
+    relation_types:
+      cites: Cites
+      is_cited_by: Is Cited By
+      is_supplement_to: Is Supplement To
+      is_supplemented_by: Is Supplemented By
+      continues: Continues
+      is_continued_by: Is Continued By
+      has_metadata: Has Metadata
+      is_metadata_for: Is Metadata For
+      is_new_version_of: Is New Version Of
+      is_previous_version_of: Is Previous Version Of
+      is_part_of: Is Part Of
+      has_part: Has Part
+      is_referenced_by: Is Referenced By
+      references: References
+      is_documented_by: Is Documented By
+      documents: Documents
+      is_compiled_by: Is Compiled By
+      compiles: Compiles
+      is_variant_form_of: Is Variant Form Of
+      is_original_form_of: Is Original Form Of
+      is_identical_to: Is Identical To
+      is_reviewed_by: Is Reviewed By
+      reviews: Reviews
+      is_derived_from: Is Derived From
+      is_source_of: Is Source Of
+      is_comment_on: Is Comment On
+      has_comment: Has Comment
+      is_reply_to: Is Reply To
+      has_reply: Has Reply
+      based_on_data: Based On Data
+      has_related_material: Has Related Material
+      is_based_on: Is Based On
+      is_basis_for: Is Basis For
+      requires: Requires
+      is_required_by: Is Required By
+      has_parent: Has Parent
+      is_parent_of: Is Parent Of

--- a/willow/spec/factories/cdm_identifier.rb
+++ b/willow/spec/factories/cdm_identifier.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+
+  factory :cdm_identifier, :class => 'Cdm::Identifier' do
+    skip_create
+    override_new_record
+  end
+
+end

--- a/willow/spec/factories/cdm_identifier_relationship.rb
+++ b/willow/spec/factories/cdm_identifier_relationship.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+
+  factory :cdm_identifier_relationship, :class => 'Cdm::IdentifierRelationship' do
+    skip_create
+    override_new_record
+  end
+
+end

--- a/willow/spec/models/cdm/identifier_relationship.spec
+++ b/willow/spec/models/cdm/identifier_relationship.spec
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Cdm::IdentifierRelationship do
+
+  describe 'related type' do
+    it 'has a related type' do
+      obj = build(:cdm_identifier_relationship, related_type: 'cited')
+      expect(obj.identifier_type).to be_kind_of String
+      expect(obj.identifier_type).to eq 'cited'
+    end
+  end
+
+  describe 'nested attributes for identifier' do
+    it 'accepts identifier attributes' do
+      obj = build(:cdm_identifier_relationship, identifier_attributes: [{ identifier_type: 'URL', identifier_value: 'http://example.com' }])
+      expect(obj.identifier).to be_kind_of ActiveFedora::Base
+      expect(obj.identifier.identifier_type).to eq 'URL'
+      expect(obj.identifier.identifier_value).to eq 'http://example.com'
+    end
+  end
+end

--- a/willow/spec/models/cdm/identifier_spec.rb
+++ b/willow/spec/models/cdm/identifier_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Cdm::Identifier do
+  # since this is a model, we just check it can build the correct fields
+
+  describe 'identifier value' do
+    it 'has an identifier value' do
+      obj = build(:cdm_identifier, identifier_value: 'test identifier value')
+      expect(obj.identifier_value).to be_kind_of String
+      expect(obj.identifier_value).to eq 'test identifier value'
+    end
+  end
+
+  describe 'identifier type' do
+    it 'has an identifier type' do
+      obj = build(:cdm_identifier, identifier_type: 'URL')
+      expect(obj.identifier_type).to be_kind_of String
+      expect(obj.identifier_type).to eq 'URL'
+    end
+  end
+end

--- a/willow/spec/models/rdss_cdm_spec.rb
+++ b/willow/spec/models/rdss_cdm_spec.rb
@@ -304,4 +304,75 @@ RSpec.describe RdssCdm do
       expect(obj.valid?).to eq true
     end
   end
+
+  describe 'nested attributes for object identifiers' do
+    it 'accepts object identifiers attributes' do
+      obj = build(:rdss_cdm, object_identifiers_attributes: [
+        {
+          identifier_type: 'URL',
+          identifier_value: 'http://example.com'
+        }
+      ])
+      expect(obj.object_identifiers.first).to be_kind_of ActiveFedora::Base
+      expect(obj.object_identifiers.first.identifier_type).to eq 'URL'
+      expect(obj.object_identifiers.first.identifier_value).to eq 'http://example.com'
+    end
+
+    it 'indexes the object identifiers' do
+      obj = build(:rdss_cdm, object_identifiers_attributes: [
+        {
+          identifier_type: 'isbn',
+          identifier_value: '12345'
+        }
+      ])
+      doc = obj.to_solr
+      expect(doc['object_identifier_isbn_ssi']).to eq('12345')
+      expect(doc).to include('object_identifiers_ssm')
+      identifiers_json = JSON.parse(doc['object_identifiers_ssm'])
+      expect(identifiers_json[0]['identifier_type']).to eq('isbn')
+      expect(identifiers_json[0]['identifier_value']).to eq('12345')
+    end
+  end
+
+  describe 'nested attributes for object related identifiers' do
+    it 'accepts object related identifiers attributes' do
+      obj = build(:rdss_cdm, object_related_identifiers_attributes: [
+        {
+          relation_type: 'cites',
+          identifier_attributes: {
+            identifier_type: 'URL',
+            identifier_value: 'http://example.com'
+          }
+        }
+      ])
+      related_identifier = obj.object_related_identifiers.first
+      expect(related_identifier).to be_kind_of ActiveFedora::Base
+      expect(related_identifier.relation_type).to eq 'cites'
+      
+      identifier = related_identifier.identifier
+      expect(identifier).to be_kind_of ActiveFedora::Base
+      expect(identifier.identifier_type).to eq 'URL'
+      expect(identifier.identifier_value).to eq 'http://example.com'
+    end
+
+    it 'indexes the object related identifiers' do
+      obj = build(:rdss_cdm, object_related_identifiers_attributes: [
+        {
+          relation_type: 'isPartOf',
+          identifier_attributes: {
+            identifier_type: 'isbn',
+            identifier_value: '12345'
+          }
+        }
+      ])
+      doc = obj.to_solr
+      expect(doc).to include('object_related_identifiers_ssm')
+      related_identifiers_json = JSON.parse(doc['object_related_identifiers_ssm'])
+      expect(related_identifiers_json[0]['relation_type']).to eq('isPartOf')
+      expect(related_identifiers_json[0]['identifier']['identifier_type']).to eq('isbn')
+      expect(related_identifiers_json[0]['identifier']['identifier_value']).to eq('12345')
+    end
+  end
+
+
 end

--- a/willow/spec/renderers/object_identifiers_attribute_renderer_spec.rb
+++ b/willow/spec/renderers/object_identifiers_attribute_renderer_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe ObjectIdentifiersAttributeRenderer do
+
+  describe 'Object Identifiers Attribute Renderer' do
+    
+    def render_identifier value
+      Nokogiri::HTML(described_class.new(:object_identifiers, value).render)
+    end
+
+    context 'when type is an enumeration value' do
+      let(:value) do
+        '{"identifier_type": "doi", "identifier_value": "12345"}'
+      end
+
+      it 'looks up and displays the label' do
+        expect(render_identifier(value).css('.td')[0].text).to eq('DOI')
+      end
+
+      it 'displays the identifier value' do
+        expect(render_identifier(value).css('.td')[1].text).to eq('12345')
+      end
+    end
+
+    context 'when type is not an enumeration value' do
+      let(:value) do
+        '{"identifier_type": "notInEnum", "identifier_value": "67890"}'
+      end
+
+      it 'it displays the type as directly entered' do
+        expect(render_identifier(value).css('.td')[0].text).to eq('notInEnum')
+      end
+
+      it 'displays the identifier value' do
+        expect(render_identifier(value).css('.td')[1].text).to eq('67890')
+      end
+    end
+  end
+end

--- a/willow/spec/renderers/object_related_identifiers_attribute_renderer_spec.rb
+++ b/willow/spec/renderers/object_related_identifiers_attribute_renderer_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+RSpec.describe ObjectRelatedIdentifiersAttributeRenderer do
+
+  describe 'Object Identifiers Attribute Renderer' do
+    
+    def render_identifier value
+      Nokogiri::HTML(described_class.new(:object_identifiers, value).render)
+    end
+
+    context 'when relation type and identifier type are enumeration values' do
+      let(:value) do
+        '{"relation_type":"cites", "identifier": {"identifier_type": "doi", "identifier_value": "12345"}}'
+      end
+
+      it 'looks up and displays the relation type label' do
+        expect(render_identifier(value).css('.td')[0].text).to eq('Cites')
+      end
+
+      it 'looks up and displays the identifier type label' do
+        expect(render_identifier(value).css('.td')[1].text).to eq('DOI')
+      end
+
+
+      it 'displays the identifier value' do
+        expect(render_identifier(value).css('.td')[2].text).to eq('12345')
+      end
+    end
+
+    context 'when relation type is not an enumeration value' do
+      let(:value) do
+        '{"relation_type":"notInEnum", "identifier": {"identifier_type": "ark", "identifier_value": "67890"}}'
+      end
+
+      it 'it displays the relatio type as directly entered' do
+        expect(render_identifier(value).css('.td')[0].text).to eq('notInEnum')
+      end
+
+      it 'looks up and displays the identifier type label' do
+        expect(render_identifier(value).css('.td')[1].text).to eq('ARK')
+      end
+
+      it 'displays the identifier value' do
+        expect(render_identifier(value).css('.td')[2].text).to eq('67890')
+      end
+    end
+
+    context 'when indentifier type is not an enumeration value' do
+      let(:value) do
+        '{"relation_type":"is_part_of", "identifier": {"identifier_type": "notInEnum", "identifier_value": "98765"}}'
+      end
+
+      it 'it displays the relatio type as directly entered' do
+        expect(render_identifier(value).css('.td')[0].text).to eq('Is Part Of')
+      end
+
+      it 'looks up and displays the identifier type label' do
+        expect(render_identifier(value).css('.td')[1].text).to eq('notInEnum')
+      end
+
+      it 'displays the identifier value' do
+        expect(render_identifier(value).css('.td')[2].text).to eq('98765')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pull request adding "Identifiers" and "Related Identifiers" to the RdssCdm form.

With respect to related identifiers, we added an intermediary model called IdentifierRelationships, that belongs_to an identifer and contains the relation_type information.

The ActiveFedora belongs_to association is not behaving correctly with `accepts_nested_attributes_for` requiring a hack in the IdentifierRelationship model that overrides `identifier_attributes=`. Specifically when adding a new identifier, the identifier_type and identifier_value attributes were not being set. Adding `autosave: true` to the relationship had no affect on this behaviour, and inverse_of is not a valid option for a belongs_to relationship.

Screenshots of the form elements and display below:

![screen shot 2018-02-09 at 10 02 58](https://user-images.githubusercontent.com/25913173/36022502-41c633ba-0d81-11e8-8b05-41bfda6ed6d8.png)
![screen shot 2018-02-09 at 10 02 45](https://user-images.githubusercontent.com/25913173/36022503-41dd5144-0d81-11e8-9145-39b2c8608bc5.png)
![screen shot 2018-02-09 at 10 08 22](https://user-images.githubusercontent.com/25913173/36022501-4197c08e-0d81-11e8-846b-46aeec0cef43.png)

