### PR TITLE
RDSSSAM 209 logged out home page work button

### DIFF
--- a/willow/config/initializers/hyrax.rb
+++ b/willow/config/initializers/hyrax.rb
@@ -133,7 +133,7 @@ Hyrax.config do |config|
   # config.work_requires_files = true
 
   # Should a button with "Share my work" show on the front page to all users (even those not logged in)?
-  # config.display_share_button_when_not_logged_in = true
+  config.display_share_button_when_not_logged_in = false
 
   # The user who runs batch jobs. Update this if you aren't using emails
   config.batch_user_key = ENV['BATCH_USER'] || 'batchuser@example.com'


### PR DESCRIPTION
- Add configuration to remove the "share your work" button from the logged out homepage

Thanks @blackrat for finding this

Logged out homepage screenshot below

![screen shot 2018-02-13 at 14 20 47](https://user-images.githubusercontent.com/25913173/36154368-234af3bc-10c9-11e8-8dcb-99560573829c.png)
