### PR TITLE
Feature/rdsssam 202 disable rdss dataset

### DIFF
--- a/willow/app/models/rdss_cdm.rb
+++ b/willow/app/models/rdss_cdm.rb
@@ -19,7 +19,7 @@ class RdssCdm < ActiveFedora::Base
   # validates :object_organisation_roles, presence: true
   # validates :object_people, presence: { message: I18n.t('willow.fields.presence', type: I18n.t('willow.fields.object_person').downcase)}
 
-  self.human_readable_type = 'RDSS CDM'
+  self.human_readable_type = 'Dataset'
 
   property :object_uuid, predicate: ::RDF::Vocab::DC11.identifier, multiple: false
   # object_title present as `title` inherited from Hyrax::CoreMetadata

--- a/willow/app/models/rdss_dataset.rb
+++ b/willow/app/models/rdss_dataset.rb
@@ -11,7 +11,7 @@ class RdssDataset < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your dataset must have a title.' }
 
-  self.human_readable_type = 'Dataset'
+  self.human_readable_type = 'RDSS Dataset'
 
   # value
   property :rating, predicate: ::RDF::Vocab::VMD.rating do |index|

--- a/willow/config/initializers/hyrax.rb
+++ b/willow/config/initializers/hyrax.rb
@@ -17,12 +17,12 @@ Hyrax.config do |config|
     # Injected via `rails g hyrax:work Article`
     config.register_curation_concern :article
   end
-  if ENV['ENABLE_RDSS_CDM_CONTENT_TYPE'] == 'true'
-    # Injected via `rails g hyrax:work RdssCdm`
-    config.register_curation_concern :rdss_cdm
+  if ENV['ENABLE_RDSS_DATASET_CONTENT_TYPE'] == 'true'
+    # Injected via `rails g hyrax:work RdssDataset`
+    config.register_curation_concern :rdss_dataset
   end
-  # Injected via `rails g hyrax:work RdssDataset`
-  config.register_curation_concern :rdss_dataset
+  # Injected via `rails g hyrax:work RdssCdm`
+  config.register_curation_concern :rdss_cdm
 
   
   # Register roles that are expected by your implementation.

--- a/willow/config/locales/rdss_cdm.en.yml
+++ b/willow/config/locales/rdss_cdm.en.yml
@@ -4,8 +4,8 @@ en:
       rdss_cdm:     fa fa-file-text-o
     select_type:
       rdss_cdm:
-        name:               Rdss Cdm
-        description:        Rdss cdm works
+        name:               Dataset
+        description:        Dataset with JISC RDSS metadata schema properties
   simple_form:
     labels:
       rdss_cdm:

--- a/willow/spec/models/rdss_cdm_spec.rb
+++ b/willow/spec/models/rdss_cdm_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe RdssCdm do
 
   it 'has human readable type rdss_cdm' do
     obj = build(:rdss_cdm)
-    expect(obj.human_readable_type).to eq('RDSS CDM')
+    expect(obj.human_readable_type).to eq('Dataset')
   end
 
   describe 'title' do

--- a/willow/spec/models/rdss_dataset_spec.rb
+++ b/willow/spec/models/rdss_dataset_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe RdssDataset do
   it 'has human readable type rdss_dataset' do
     @obj = build(:rdss_dataset)
-    expect(@obj.human_readable_type).to eq('Dataset')
+    expect(@obj.human_readable_type).to eq('RDSS Dataset')
   end
 
   describe 'title' do


### PR DESCRIPTION
This pull request disables the Rdss Dataset and turns on the new RdssCdm form by default.

In addition it makes changes to the humanised versions of the models to present the new RdssCdm Model as simply "Dataset"

This should be able to be deployed to HEIs without any changes to the ENV variables in the installations.