### PR TITLE
Feature/rdsssam 232 license to licence

### DIFF
--- a/willow/app/forms/hyrax/rdss_cdm_form.rb
+++ b/willow/app/forms/hyrax/rdss_cdm_form.rb
@@ -122,7 +122,7 @@ module Hyrax
         [
           rights_statement: [],
           rights_holder: [],
-          license: [],
+          licence: [],
           accesses_attributes: [
             :id,
             :_destroy,

--- a/willow/app/indexers/rdss_cdm_indexer.rb
+++ b/willow/app/indexers/rdss_cdm_indexer.rb
@@ -38,7 +38,7 @@ class RdssCdmIndexer < Hyrax::WorkIndexer
       # index the object_rights fields as direct fields on the solr document
       rights = object.object_rights.first
       if rights
-        solr_doc[Solrizer.solr_name('object_rights_license', :stored_searchable)] = rights.license
+        solr_doc[Solrizer.solr_name('object_rights_licence', :stored_searchable)] = rights.licence
         solr_doc[Solrizer.solr_name('object_rights_rights_statement', :stored_searchable)] = rights.rights_statement
         solr_doc[Solrizer.solr_name('object_rights_rights_holder', :stored_searchable)] = rights.rights_holder
         # nested accesses

--- a/willow/app/inputs/object_rights_form_builder.rb
+++ b/willow/app/inputs/object_rights_form_builder.rb
@@ -1,10 +1,10 @@
 class ObjectRightsFormBuilder < RdssFields
-  def license
-    input :license, 
+  def licence
+    input :licence, 
       as: :multi_value_select, 
       collection: Hyrax::LicenseService.new.select_active_options, 
       input_html: {
-        prompt: I18n.t('simple_form.prompts.rdss_cdm.object_rights.license')
+        prompt: I18n.t('simple_form.prompts.rdss_cdm.object_rights.licence')
       },
       required: true
   end

--- a/willow/app/models/cdm/rights.rb
+++ b/willow/app/models/cdm/rights.rb
@@ -3,7 +3,7 @@ module Cdm
   class Rights < ActiveFedora::Base
     property :rights_statement, predicate: ::RDF::Vocab::DC.RightsStatement
     property :rights_holder, predicate: ::RDF::Vocab::DC.rightsHolder
-    property :license, predicate: ::RDF::Vocab::DC.license
+    property :licence, predicate: ::RDF::Vocab::DC.license
     # TODO deep nested association for access object
 
     # Define relationship with rdss_cdm model

--- a/willow/app/models/concerns/rdss_cdm_extensions.rb
+++ b/willow/app/models/concerns/rdss_cdm_extensions.rb
@@ -8,7 +8,7 @@ module Concerns
                       :object_category,
                       :object_resource_type,
                       :object_value,
-                      :object_rights_license,
+                      :object_rights_licence,
                       :object_rights_rights_statement,
                       :object_rights_rights_holder
 

--- a/willow/app/presenters/hyrax/rdss_cdm_presenter.rb
+++ b/willow/app/presenters/hyrax/rdss_cdm_presenter.rb
@@ -11,7 +11,7 @@ module Hyrax
              :object_dates,
              :object_people,
              :object_person_roles,
-             :object_rights_license,
+             :object_rights_licence,
              :object_rights_rights_statement,
              :object_rights_rights_holder,
              :object_rights_accesses,

--- a/willow/app/renderers/object_rights_licence_attribute_renderer.rb
+++ b/willow/app/renderers/object_rights_licence_attribute_renderer.rb
@@ -1,6 +1,6 @@
 # Overrides the default `li_value` behaviour and creates a faceted attribute
 # link with a humanized value.
-class ObjectRightsLicenseAttributeRenderer < Hyrax::Renderers::AttributeRenderer
+class ObjectRightsLicenceAttributeRenderer < Hyrax::Renderers::AttributeRenderer
   include Utils
 
   private

--- a/willow/app/views/hyrax/rdss_cdms/_attribute_rows.html.erb
+++ b/willow/app/views/hyrax/rdss_cdms/_attribute_rows.html.erb
@@ -8,7 +8,7 @@
 <%= presenter.attribute_to_html(:object_people, render_as: :object_people, label:I18n.t('willow.fields.object_people')) %>
 <%= presenter.attribute_to_html(:object_dates, render_as: :object_dates, label: I18n.t('willow.fields.object_dates')) %><%# the `:render_as` parameter tells the presenter to use the object_dates_attribute_renderer %>
 <%# rights information %>
-<%= presenter.attribute_to_html(:object_rights_license, render_as: :object_rights_license) %>
+<%= presenter.attribute_to_html(:object_rights_licence, render_as: :object_rights_licence) %>
 <%= presenter.attribute_to_html(:object_rights_rights_statement) %>
 <%= presenter.attribute_to_html(:object_rights_rights_holder) %>
 <%= presenter.attribute_to_html(:object_rights_accesses, render_as: :object_rights_accesses) %>

--- a/willow/app/views/hyrax/rdss_cdms/_object_rights_form.html.erb
+++ b/willow/app/views/hyrax/rdss_cdms/_object_rights_form.html.erb
@@ -1,4 +1,4 @@
-<%= object_rights_form.license %>
+<%= object_rights_form.licence %>
 <%= object_rights_form.rights_holder %>
 <%= object_rights_form.rights_statement %>
 <%# only output the label and the hint text. wrapper defined in config/initializers/simple_form_rdss.rb %>

--- a/willow/config/locales/en.yml
+++ b/willow/config/locales/en.yml
@@ -69,7 +69,7 @@ en:
       presence: 'Your work must have a %{type}.'
       object_people: People
       access: Access
-      object_rights_license: License
+      object_rights_licence: Licence
       object_organisation_role: Organisation role
       given_and_family_name_presence: a minimum of given or family name
       object_identifier: Identifier

--- a/willow/config/locales/hyrax.en.yml
+++ b/willow/config/locales/hyrax.en.yml
@@ -32,7 +32,7 @@ en:
           object_keywords: Keywords
           object_category: Category
           object_resource_type: Resource type
-          object_rights_license: License
+          object_rights_licence: Licence
           object_rights_rights_statement: Rights statement
           object_rights_rights_holder: Rights holder
           object_rights_accesses: Access

--- a/willow/config/locales/rdss_cdm.en.yml
+++ b/willow/config/locales/rdss_cdm.en.yml
@@ -44,7 +44,7 @@ en:
         # rather than simple_form.hints.rdss_cdm.object_rights, as otherwise the translation
         # for simple_form.hints.rdss_cdm.object_rights
         # would return a hash
-        license: Licensing and distribution information governing access to the dataset.
+        licence: Licensing and distribution information governing access to the dataset.
         rights_holder: The person or organisation who holds the rights for the work
     prompts:
       rdss_cdm:
@@ -54,7 +54,7 @@ en:
         object_person_role:
           role_type: Choose role
         object_rights:
-          license: Select license
+          licence: Select licence
         object_identifiers:
           identifier_type: Select type
         object_related_identifiers:

--- a/willow/spec/models/cdm/rights_spec.rb
+++ b/willow/spec/models/cdm/rights_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe Cdm::Rights do
     end
   end
     
-  describe 'license' do
-    it 'has a license' do
-      obj = build(:cdm_rights, license: ['http://creativecommons.org/licenses/by/3.0/us/'])
-      expect(obj.license).to be_kind_of ActiveTriples::Relation
-      expect(obj.license).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
+  describe 'licence' do
+    it 'has a licence' do
+      obj = build(:cdm_rights, licence: ['http://creativecommons.org/licenses/by/3.0/us/'])
+      expect(obj.licence).to be_kind_of ActiveTriples::Relation
+      expect(obj.licence).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
     end
   end
 

--- a/willow/spec/models/rdss_cdm_spec.rb
+++ b/willow/spec/models/rdss_cdm_spec.rb
@@ -249,14 +249,14 @@ RSpec.describe RdssCdm do
             {
               rights_statement: ['test rights statement'],
               rights_holder: ['test rights holder'],
-              license: ['http://creativecommons.org/licenses/by/3.0/us/'],
+              licence: ['http://creativecommons.org/licenses/by/3.0/us/'],
               accesses_attributes: [{ access_type: 'controlled', access_statement: 'Statement 1' }]
             }
           ])
       expect(obj.object_rights.first).to be_kind_of ActiveFedora::Base
       expect(obj.object_rights.first.rights_statement).to eq ['test rights statement']
       expect(obj.object_rights.first.rights_holder).to eq ['test rights holder']
-      expect(obj.object_rights.first.license).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
+      expect(obj.object_rights.first.licence).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
       expect(obj.object_rights.first.accesses.first.access_type).to eq 'controlled'
       expect(obj.object_rights.first.accesses.first.access_statement).to eq 'Statement 1'
     end
@@ -266,12 +266,12 @@ RSpec.describe RdssCdm do
             {
               rights_statement: ['another rights statement'],
               rights_holder: ['another rights holder'],
-              license: ['http://creativecommons.org/licenses/by/3.0/us/'],
+              licence: ['http://creativecommons.org/licenses/by/3.0/us/'],
               accesses_attributes: [{ access_type: 'controlled', access_statement: 'Statement 2' }]
             }
           ])
       doc = obj.to_solr
-      expect(doc['object_rights_license_tesim']).to eq(['http://creativecommons.org/licenses/by/3.0/us/'])
+      expect(doc['object_rights_licence_tesim']).to eq(['http://creativecommons.org/licenses/by/3.0/us/'])
       expect(doc['object_rights_rights_statement_tesim']).to eq(['another rights statement'])
       expect(doc['object_rights_rights_holder_tesim']).to eq(['another rights holder'])
       expect(doc['object_rights_access_type_tesim']).to eq(['controlled'])


### PR DESCRIPTION
Fixing spelling of Licence within the RdssCdm workflow.

Note that there are some American spellings within Hyrax code that I couldn't change. Eg. LicenseService and the license predicate.

I also haven't touched the spelling in the workflow for the old cottagelabs Curation Concerns