### PR TITLE
Feature/rdsssam 137 translation missing

### DIFF
--- a/willow/config/locales/hyrax.en.yml
+++ b/willow/config/locales/hyrax.en.yml
@@ -66,3 +66,6 @@ en:
     footer:
       copyright_html: "<strong>Copyright &copy; 2017 Samvera</strong> Licensed under the Apache License, Version 2.0"
       service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
+    collections:
+      new:
+        header: New Collection


### PR DESCRIPTION
Having investigated further (involving overriding the breadcrumb builders), there is a default translation look up for

en.hyrax.collections.new.header

I've added in this translation as "New Collection"

Just a word on capitalisation. I know we have tended towards Scentence Case rather than title case for form labels etc, but all the breadcrumbs and navigation elements are at the moment in title case, so I have stuck with this.

- Adding missing new collection translation