### PR TITLE
Feature/rdsssam 221 works created link broken

### DIFF
--- a/willow/app/controllers/blacklight/concerns/commands.rb
+++ b/willow/app/controllers/blacklight/concerns/commands.rb
@@ -60,7 +60,7 @@ module Blacklight
                                                                 else
                                                                   [name, name, :stored_searchable, options]
                                                                 end
-          local_params_solr_name = send(index_type, name, *solr_options)
+          local_params_solr_name = send("#{index_type}_name", name, *solr_options)
           config.add_search_field(name.to_s) do |field|
             field.label=default_label(label_name)
             field.solr_local_parameters={ qf: local_params_solr_name, pf: local_params_solr_name }

--- a/willow/app/controllers/catalog_controller.rb
+++ b/willow/app/controllers/catalog_controller.rb
@@ -257,7 +257,7 @@ class CatalogController < ApplicationController
                      {identifier: {name: :id}},
                      {based_near: {name: :based_near_label}},
                      :keyword,
-                     :depositor,
+                     {depositor: {as: :symbol}},
                      :rights,
                      :license_nested,
                      :other_title,


### PR DESCRIPTION
The following commits correct the blacklight configuration for adding search fields.

The error that was causing defect 221 was that the parameter for search field was coming through to blacklight as [:depositor] whereas it was expecting a string.

Two fixes were needed:
- fixing the blacklight configuration so that depositor was added as a symbol search field
- fixing Blacklight::Concerns::Commmands#add_solr_search_field so that it called `depositor_name` rather than `depositor`

I've tested locally and the link to works created now correctly lists works deposited by the user