### PR TITLE
Feature/rdsssam 229 change title back to multivalue version2

### DIFF
--- a/willow/app/actors/hyrax/actors/rdss_cdm_actor.rb
+++ b/willow/app/actors/hyrax/actors/rdss_cdm_actor.rb
@@ -5,12 +5,10 @@ module Hyrax
     class RdssCdmActor < Hyrax::Actors::BaseActor
       def create(env)
         add_object_uuid(env)
-        title_to_array(env)
         super
       end
 
       def update(env)
-        title_to_array(env)
         super
       end
 
@@ -19,10 +17,6 @@ module Hyrax
           unless env.attributes.key?(:object_uuid)
             env.attributes[:object_uuid] = SecureRandom.uuid
           end
-        end
-
-        def title_to_array(env)
-          env.attributes[:title] = Array(env.attributes[:title]) if env.attributes[:title]
         end
     end
   end

--- a/willow/app/models/cdm/messaging/object_title.rb
+++ b/willow/app/models/cdm/messaging/object_title.rb
@@ -1,9 +1,14 @@
 # Endpoint for objectTitle message element. This is called :title in the model.
+# In the model the title is an array of values, but for the purposes of messaging and the
+# form it is a single valued String
 module Cdm
   module Messaging
     class ObjectTitle < MessageMapper
-      include AttributeMapper
-      attribute_name :title
+      
+      # override MessageMapper#value to return the first value in the title array
+      def value(object, _unused)
+        object.title.first
+      end
     end
   end
 end

--- a/willow/app/models/rdss_cdm.rb
+++ b/willow/app/models/rdss_cdm.rb
@@ -76,26 +76,6 @@ class RdssCdm < ActiveFedora::Base
   accepts_nested_attributes_for :object_identifiers, allow_destroy: true, reject_if: :object_identifiers_blank?
   accepts_nested_attributes_for :object_related_identifiers, allow_destroy: true, reject_if: :object_related_identifiers_blank?
 
-  def self.multiple?(field)
-    # Overriding to return false for `title` (as we can't set multiple: false)
-    if [:title].include? field.to_sym
-      false
-    else
-      super
-    end
-  end
-
-  def self.model_attributes(_)
-    # Overriding to cast title back to multivalue when saving.
-    attrs = super
-    attrs[:title] = Array(attrs[:title]) if attrs[:title]
-    attrs
-  end
-
-  def title
-    # Return a single value for form field population.
-    super.first || ""
-  end
 
   # The following properties are also inherited from Hyrax::CoreMetadata
   # along with :title and are required by Hyrax:

--- a/willow/app/views/rdss_cdms/edit_fields/_title.html.erb
+++ b/willow/app/views/rdss_cdms/edit_fields/_title.html.erb
@@ -1,0 +1,1 @@
+<%= f.input :title, input_html: {name: "#{f.object_name}[title][]", value: f.object.title.try(:first)} %>

--- a/willow/spec/actors/hyrax/actors/rdss_cdm_actor_spec.rb
+++ b/willow/spec/actors/hyrax/actors/rdss_cdm_actor_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Hyrax::Actors::RdssCdmActor do
   let(:env) { Hyrax::Actors::Environment.new(rdss_cdm, ability, attributes) }
   let(:terminator) { Hyrax::Actors::Terminator.new }
   let(:depositor) { create(:user) }
-  let(:attributes) { {:title => "a test title"} }
+  let(:attributes) { {:title => ["a test title"]} }
   let(:rdss_cdm) { create(:rdss_cdm) }
 
   subject(:middleware) do
@@ -22,20 +22,6 @@ RSpec.describe Hyrax::Actors::RdssCdmActor do
     it 'adds an object_uuid' do 
       VCR.use_cassette('rdss_cdm_actor/create_object_uuid', :match_requests_on => [:method, :host]) do
         expect { middleware.create(env) }.to change { env.attributes[:object_uuid] }.to match(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
-      end
-    end
-
-    it 'changes title property to an array' do
-      VCR.use_cassette('rdss_cdm_actor/create_title_array', :match_requests_on => [:method, :host]) do
-        expect { middleware.create(env) }.to change { env.attributes[:title].instance_of? Array }.to(true)
-      end
-    end
-  end
-
-  describe "update" do
-    it 'changes title property to an array' do
-      VCR.use_cassette('rdss_cdm_actor/update_title_array', :match_requests_on => [:method, :host]) do
-        expect { middleware.update(env) }.to change { env.attributes[:title].instance_of? Array }.to(true)
       end
     end
   end

--- a/willow/spec/actors/hyrax/actors/rdss_cdm_object_versioning_actor_spec.rb
+++ b/willow/spec/actors/hyrax/actors/rdss_cdm_object_versioning_actor_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hyrax::Actors::RdssCdmObjectVersioningActor do
   end
 
   describe "create" do
-    let(:attributes) { {:object_version => "", :title => "test title"} }
+    let(:attributes) { {:object_version => "", :title => ["test title"]} }
     let(:rdss_cdm) { create(:rdss_cdm) }
     let(:env) { Hyrax::Actors::Environment.new(rdss_cdm, ability, attributes) }
     it 'set object version to 1' do
@@ -25,7 +25,7 @@ RSpec.describe Hyrax::Actors::RdssCdmObjectVersioningActor do
   end
 
   describe "minor update" do
-    let(:attributes) { {:object_version => "1", :title => "test title"} }
+    let(:attributes) { {:object_version => "1", :title => ["test title"]} }
     let(:rdss_cdm) { create(:rdss_cdm, title: ["test title"], object_version: "1", state: active_state) }
     let(:env) { Hyrax::Actors::Environment.new(rdss_cdm, ability, attributes) }
     it 'object version remains 1' do
@@ -34,7 +34,7 @@ RSpec.describe Hyrax::Actors::RdssCdmObjectVersioningActor do
   end
 
   describe "major update to title" do
-    let(:attributes) { {:object_version => "1", :title => "another test title"} }
+    let(:attributes) { {:object_version => "1", :title => ["another test title"]} }
     let(:rdss_cdm) { create(:rdss_cdm, title: ["test title"], object_version: "1", state: active_state) }
     let(:env) { Hyrax::Actors::Environment.new(rdss_cdm, ability, attributes) }
     it 'object version increments to 2' do
@@ -43,7 +43,7 @@ RSpec.describe Hyrax::Actors::RdssCdmObjectVersioningActor do
   end
 
   describe "major update to uploaded files" do
-    let(:attributes) { {:object_version => "1", :title => "test title", :uploaded_files => [1,2]} }
+    let(:attributes) { {:object_version => "1", :title => ["test title"], :uploaded_files => [1,2]} }
     let(:rdss_cdm) { create(:rdss_cdm, title: ["test title"], object_version: "1", state: active_state) }
     let(:env) { Hyrax::Actors::Environment.new(rdss_cdm, ability, attributes) }
     it 'object version increments to 2' do

--- a/willow/spec/actors/hyrax/actors/versioning/significant_field_changed_spec.rb
+++ b/willow/spec/actors/hyrax/actors/versioning/significant_field_changed_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SignificantFieldsChanged do
   let(:depositor) { create(:user) }
 
   describe "Significant fields have changed by title" do
-    let(:attributes) { {:title => "A different test title"} }
+    let(:attributes) { {:title => ["A different test title"]} }
     let(:rdss_cdm) { create(:rdss_cdm, title: ["A test title"] ) }
     let(:env) { Hyrax::Actors::Environment.new(rdss_cdm, ability, attributes) }
     it 'the work title has changed' do
@@ -15,7 +15,7 @@ RSpec.describe SignificantFieldsChanged do
   end
 
   describe "Significant fields have changed by uploaded files" do
-    let(:attributes) { {:title => "A test title", :uploaded_files => [1] } }
+    let(:attributes) { {:title => ["A test title"], :uploaded_files => [1] } }
     let(:rdss_cdm) { create(:rdss_cdm, title: ["A test title"] ) }
     let(:env) { Hyrax::Actors::Environment.new(rdss_cdm, ability, attributes) }
     it 'the work has an uploaded file' do
@@ -24,7 +24,7 @@ RSpec.describe SignificantFieldsChanged do
   end
 
   describe "Significant fields have not changed" do
-    let(:attributes) { {:title => "A test title"} }
+    let(:attributes) { {:title => ["A test title"]} }
     let(:rdss_cdm) { create(:rdss_cdm, title: ["A test title"] ) }
     let(:env) { Hyrax::Actors::Environment.new(rdss_cdm, ability, attributes) }
     it 'the work title has not changed' do

--- a/willow/spec/models/rdss_cdm_spec.rb
+++ b/willow/spec/models/rdss_cdm_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe RdssCdm do
 
     it 'has a single valued title field' do
       obj = build(:rdss_cdm, title: ['test rdss_cdm']) # Note it's actually multivalue so we set it as an array
-      expect(obj.title).to eq 'test rdss_cdm' # but title is returned as a single string
+      expect(obj.title).to eq ['test rdss_cdm'] # it's returned as an array
     end
 
     it 'indexes title' do


### PR DESCRIPTION
This branch fixes the notification bug issue by changing title to multi-value in the model layer, and pushing all single value functionality to the form and messaging layer.

The actor stack was also changed to remove the conversion to an array, although this was not actually breaking as

` Array([1]) == Array(1) == [1]`

Note that the main culprit causing the notifications to break was the overridden RdssCdm#title method, which has now been removed