### PR TITLE
Use temporary local database for asset precompilation

### DIFF
--- a/willow/Dockerfile
+++ b/willow/Dockerfile
@@ -76,7 +76,7 @@ RUN cd $APP_PRODUCTION \
 # generate production assets if production environment
 RUN if [ "$RAILS_ENV" = "production" ]; then \
         cd $APP_PRODUCTION \
-        && SECRET_KEY_BASE_PRODUCTION=0 bundle exec rake -v --trace=stdout assets:clean assets:precompile; \
+        && SECRET_KEY_BASE_PRODUCTION=0 ASSET_PRECOMPILATION_ADAPTER=sqlite3 bundle exec rake -v --trace=stdout assets:clean assets:precompile; \
     fi
 
 WORKDIR $APP_WORKDIR

--- a/willow/Gemfile
+++ b/willow/Gemfile
@@ -67,3 +67,4 @@ gem 'wisper', '2.0.0'
 
 gem 'riiif', '~> 1.1'
 gem 'noid-rails'
+gem 'sqlite3'

--- a/willow/Gemfile.lock
+++ b/willow/Gemfile.lock
@@ -762,6 +762,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sqlite3 (1.3.13)
     stomp (1.4.4)
     sxp (1.0.1)
       rdf (>= 2.2, < 4.0)
@@ -846,6 +847,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   solr_wrapper (>= 0.3)
+  sqlite3
   tinymce-rails-imageupload (= 4.0.17.beta.2)
   turbolinks (~> 5)
   uglifier (>= 1.3.0)

--- a/willow/config/database.yml
+++ b/willow/config/database.yml
@@ -18,4 +18,5 @@ test:
 
 production:
   <<: *default
+  adapter: <%= ENV.fetch("ASSET_PRECOMPILATION_ADAPTER") { 'postgresql' } %>
   database: willow_production


### PR DESCRIPTION
This is slightly less terrible that it could have been. By using the sqlite3 adapter for just the precompilation step, it bypasses the check for 'db' as a host, since sqlite3 is a local database only.
The only thing that had to be done was to set and test for an environment variable for the call
to the asset precompile.