### PR TITLE
Switching licence rendering in message generation to use

### DIFF
--- a/willow/app/models/cdm/messaging/licence.rb
+++ b/willow/app/models/cdm/messaging/licence.rb
@@ -6,13 +6,9 @@
 module Cdm
   module Messaging
     class Licence < MessageMapper
-      def normalize(object)
-        object.tr('^a-zA-Z0-9','_')
-      end
-
       def hash_value(_, object)
         {
-          licenceName: object.present? && I18n.t("rdss.licences.#{normalize(object)}") || '',
+          licenceName: object.present? && Hyrax::LicenseService.new.label(object) || '',
           licenceIdentifier: object
         }
       end


### PR DESCRIPTION
We've update the message rendering to use Hyrax::LicenceService to get the licence names from the stored url identifiers. There were a number of licenses that could not be found  when using the previous approach. 