### PR TITLE
Fix sort order in html-5 attributes rather than js

### DIFF
--- a/willow/app/assets/javascripts/application.js
+++ b/willow/app/assets/javascripts/application.js
@@ -24,4 +24,3 @@
 //= require_tree .
 //= require hyrax
 //= require collections-csrf-bugfix
-//= require notifications

--- a/willow/app/assets/javascripts/notifications.js
+++ b/willow/app/assets/javascripts/notifications.js
@@ -1,8 +1,0 @@
-'use strict';
-
-$(document).ready(function() {
-  $('#notifications_table').DataTable( {
-    "order": [[ 0, 'desc']]
-  })
-  }
-);

--- a/willow/app/views/hyrax/notifications/_notifications.html.erb
+++ b/willow/app/views/hyrax/notifications/_notifications.html.erb
@@ -4,7 +4,7 @@
 <!--data-sort attribute below-->
 <% if messages.present? %>
   <div class="table-responsive">
-    <table class="table table-striped datatable" id="notifications_table">
+    <table class="table table-striped datatable" data-order="[[ 0, &quot;desc&quot; ]]" >
       <thead>
         <tr>
           <th><%= t('hyrax.mailbox.date') %></th>


### PR DESCRIPTION
Turns out that you can do this by specifying the javascript ordering in the html5 data- attribute. A much cleaner way of handling it.