### PR TITLE
Remove metadata_only from required fields.

### DIFF
--- a/willow/app/forms/hyrax/rdss_cdm_form.rb
+++ b/willow/app/forms/hyrax/rdss_cdm_form.rb
@@ -24,7 +24,6 @@ module Hyrax
 
     self.required_fields = [
       :title,
-      :metadata_only,
       :object_description,
       :object_resource_type,
       :object_value,


### PR DESCRIPTION
This field should not be required if it's a checkbox, as the form can't then be submitted without it being checked. 