### PR TITLE
Remove FileRight values, since they are optional in the V3.0.1 messages

### DIFF
--- a/willow/app/models/cdm/messaging/file_right.rb
+++ b/willow/app/models/cdm/messaging/file_right.rb
@@ -1,7 +1,10 @@
 #Endpoint that has the same effective name in the mapping and the model. objectRights maps to :object_rights
 module Cdm
   module Messaging
-    class FileRight < EmptyMapper
+    class FileRight < MessageMapper
+      def hash_value(_, object)
+        nil
+      end
     end
   end
 end

--- a/willow/app/models/cdm/messaging/file_right.rb
+++ b/willow/app/models/cdm/messaging/file_right.rb
@@ -1,21 +1,7 @@
 #Endpoint that has the same effective name in the mapping and the model. objectRights maps to :object_rights
 module Cdm
   module Messaging
-    class FileRight < MessageMapper
-      def hash_value(_, object)
-        {
-          rightsStatement: [ 'not yet implemented' ],
-          rightsHolder: [ 'not yet implemented' ],
-          licence: [
-            licenceName: '',
-            licenceIdentifier: ''
-          ],
-          access: [
-            accessType: 3,
-            accessStatement: 'not yet implemented'
-          ]
-        }
-      end
+    class FileRight < EmptyMapper
     end
   end
 end

--- a/willow/spec/models/cdm/messaging/file_rights_spec.rb
+++ b/willow/spec/models/cdm/messaging/file_rights_spec.rb
@@ -23,22 +23,7 @@ RSpec.describe ::Cdm::Messaging::FileRight do
   }
 
   let(:expected_value) {
-    {
-      rightsStatement: ['not yet implemented'],
-      rightsHolder: ['not yet implemented'],
-      licence: [
-        {
-          licenceName: '',
-          licenceIdentifier: ''
-        }
-      ],
-      access: [
-        {
-          accessType: 3,
-          accessStatement: 'not yet implemented'
-        }
-      ]
-    }
+    nil
   }
 
   describe 'decodes messaging sections' do


### PR DESCRIPTION
FileRight values have changed in the v3.0.1 messaging spec, but they should be entirely optional, so rather than passing in the empty strings, let's just remove the entire section.