### PR TITLE
Fix the workaround for object_related_identifier

### DIFF
--- a/willow/app/models/cdm/messaging/identifier.rb
+++ b/willow/app/models/cdm/messaging/identifier.rb
@@ -1,0 +1,9 @@
+module Cdm
+  module Messaging
+    class Identifier < MessageMapper
+      def hash_value(message_map, object)
+        super(message_map, object.identifier)
+      end
+    end
+  end
+end

--- a/willow/app/models/cdm/messaging/object_related_identifier.rb
+++ b/willow/app/models/cdm/messaging/object_related_identifier.rb
@@ -1,20 +1,8 @@
-# TODO: The messaging format and CDM don't quite match or make perfect sense for ObjectIdentifier and ObjectRelatedIdentifier
-# The standard hashing is overridden to force a valid relation_type in here, even though it shouldn't be required for ObjectIdentifier
-# and the hash_value method should be removed when the correct messaging map is applied.
 module Cdm
   module Messaging
     class ObjectRelatedIdentifier < MessageMapper
       include AttributeMapper
       attribute_name :object_related_identifiers
-
-      def hash_value(message_map, object)
-        {
-          relationType: Enumerations::RelationType.send(object.relation_type),
-          identifierType: Enumerations::IdentifierType.send(object.identifier.identifier_type),
-          identifierValue: object.identifier.identifier_value
-        }
-      end
-
     end
   end
 end

--- a/willow/app/models/cdm/messaging/relation_type.rb
+++ b/willow/app/models/cdm/messaging/relation_type.rb
@@ -1,0 +1,9 @@
+# TODO: The messaging format and CDM don't quite match or make perfect sense for ObjectIdentifier and ObjectRelatedIdentifier
+# The standard hashing is overridden to force a valid relation_type in here, even though it shouldn't be required for ObjectIdentifier
+# and the hash_value method should be removed when the correct messaging map is applied.
+module Cdm
+  module Messaging
+    class RelationType < EnumerationMapper
+    end
+  end
+end

--- a/willow/spec/models/cdm/messaging/rdss_cdm_spec.rb
+++ b/willow/spec/models/cdm/messaging/rdss_cdm_spec.rb
@@ -120,8 +120,10 @@ RSpec.describe ::Cdm::Messaging::RdssCdm do
         objectRelatedIdentifier: [
           {
             relationType: 1,
-            identifierType: 17,
-            identifierValue: 'http://example.com',
+            identifier: {
+              identifierType: 17,
+              identifierValue: 'http://example.com'
+            },
           }
         ],
         objectOrganisationRole: [


### PR DESCRIPTION
Remove the forced structure change for 2.1.0.