### PR TITLE
Add full namespace around files to allow for autoload to find them

### DIFF
--- a/willow/lib/rdss/messaging/generators/core/version_mapper.rb
+++ b/willow/lib/rdss/messaging/generators/core/version_mapper.rb
@@ -1,8 +1,14 @@
-module Core
-  module VersionMapper
-    class << self
-      def included(base)
-        ::Junctions.activate(base, self.name)
+module Rdss
+  module Messaging
+    module Generators
+      module Core
+        module VersionMapper
+          class << self
+            def included(base)
+              ::Junctions.activate(base, self.name)
+            end
+          end
+        end
       end
     end
   end

--- a/willow/lib/rdss/messaging/generators/generate_header.rb
+++ b/willow/lib/rdss/messaging/generators/generate_header.rb
@@ -4,7 +4,7 @@ module Rdss
   module Messaging
     module Generators
       class GenerateHeader
-        include Core::VersionMapper
+        include ::Rdss::Messaging::Generators::Core::VersionMapper
         class << self
           def call(event: :create, version: :current, errors: [])
             new(event: event, version: version).call(errors: errors)

--- a/willow/lib/rdss/messaging/generators/messaging121/version_mapper.rb
+++ b/willow/lib/rdss/messaging/generators/messaging121/version_mapper.rb
@@ -1,7 +1,13 @@
-module Messaging121
-  module VersionMapper
-    def default_version
-      '1.2.1'
+module Rdss
+  module Messaging
+    module Generators
+      module Messaging121
+        module VersionMapper
+          def default_version
+            '1.2.1'
+          end
+        end
+      end
     end
   end
 end

--- a/willow/lib/rdss/messaging/generators/messaging210/version_mapper.rb
+++ b/willow/lib/rdss/messaging/generators/messaging210/version_mapper.rb
@@ -1,7 +1,13 @@
-module Messaging210
-  module VersionMapper
-    def default_version
-      '2.1.0'
+module Rdss
+  module Messaging
+    module Generators
+      module Messaging210
+        module VersionMapper
+          def default_version
+            '2.1.0'
+          end
+        end
+      end
     end
   end
 end

--- a/willow/lib/rdss/messaging/generators/messaging301/version_mapper.rb
+++ b/willow/lib/rdss/messaging/generators/messaging301/version_mapper.rb
@@ -1,7 +1,13 @@
-module Messaging301
-  module VersionMapper
-    def default_version
-      '3.0.1'
+module Rdss
+  module Messaging
+    module Generators
+      module Messaging301
+        module VersionMapper
+          def default_version
+            '3.0.1'
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Namespacing wasn't finding just children, since it expected the full namespace. Meddling with the autoload path to allow for a better structure is out of scope right now, so just add in the missing namespaces.